### PR TITLE
Updated Joplin retrofit plan example notebook to use public hazards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Remove incorrect characterization of population dislocation dataset [185](https://github.com/IN-CORE/incore-docs/issues/185)
 
 ### Fixed
+- Joplin retrofit plan example notebook to use public space hazards [#175](https://github.com/IN-CORE/pyincore/issues/175)
 - Remove broken images from mmsa notebook [156](https://github.com/IN-CORE/incore-docs/issues/156)
 - Typo in Lumberton testbed notebook [189](https://github.com/IN-CORE/incore-docs/issues/189)
 - Removed testbed name from CGE data type [#265](https://github.com/IN-CORE/pyincore/issues/265)

--- a/manual_jb/content/notebooks/retrofit_plan_Joplin_2021_12_01/retrofit_plan_Joplin_2021_12_01.ipynb
+++ b/manual_jb/content/notebooks/retrofit_plan_Joplin_2021_12_01/retrofit_plan_Joplin_2021_12_01.ipynb
@@ -1090,7 +1090,7 @@
    "outputs": [],
    "source": [
     "# list of simulated tornado event in INCORE\n",
-    "hazards_list = [\"602709015b580037c0d40090\",\"60270931cebd090981cbb66d\"]  \n",
+    "hazards_list = [\"63237dd25503e755037f4b04\",\"632373039ae7bb606e8adb68\"]  \n",
     "\n",
     "# the full list of simulated tornadoes.\n",
     "# hazards_list = [\"602709015b580037c0d40090\",\"60270931cebd090981cbb66d\",\"60270954b02d597160210968\",\n",
@@ -1200,7 +1200,7 @@
     {
      "data": {
       "text/plain": [
-       "0.026634382566585957"
+       "0.02785352551616673"
       ]
      },
      "execution_count": 42,


### PR DESCRIPTION
Updated the joplin retrofit plan example notebook to use public hazard data.