### PR TITLE
284 create_network_dataset.ipynb fails on nx.info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Update damage analysis documentations with hazard object input [#282](https://github.com/IN-CORE/incore-docs/issues/282)
 
+### Fixed
+- The notebook create_network_dataset.ipynb fails on nx.info [#284](https://github.com/IN-CORE/incore-docs/issues/284)
+
 ## [4.6.0] - 2023-10-11
 
 ### Added

--- a/manual_jb/content/notebooks/create_network_dataset/create_network_dataset.ipynb
+++ b/manual_jb/content/notebooks/create_network_dataset/create_network_dataset.ipynb
@@ -96,7 +96,7 @@
     "# instead of reading it from the graph file\n",
     "g, node_coords = NetworkUtil.create_network_graph_from_link(link_filepath, fromnode_fldname, tonode_fldname, is_directed=True)\n",
     "print(node_coords)\n",
-    "print(nx.info(g))\n",
+    "print(g)\n",
     "nx.draw(g, node_coords)"
    ]
   },

--- a/manual_jb/content/notebooks/create_network_dataset/create_network_dataset.ipynb
+++ b/manual_jb/content/notebooks/create_network_dataset/create_network_dataset.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
      "start_time": "2023-10-23T14:56:54.196461Z",
@@ -35,14 +35,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
      "start_time": "2023-10-23T14:56:56.525730Z",
      "end_time": "2023-10-23T14:57:06.236064Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connection successful to IN-CORE services. pyIncore version detected: 1.12.0\n"
+     ]
+    }
+   ],
    "source": [
     "client = IncoreClient()\n",
     "datasvc = DataService(client)"
@@ -57,14 +65,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "start_time": "2023-10-23T14:57:10.022062Z",
      "end_time": "2023-10-23T14:57:10.181272Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset already exists locally. Reading from local cached zip.\n",
+      "Unzipped folder found in the local cache. Reading from it...\n",
+      "network_graph.csv successfully created.\n"
+     ]
+    }
+   ],
    "source": [
     "# get link dataset from data service\n",
     "centerville_epn_link = '5b1fdc2db1cf3e336d7cecc9'\n",
@@ -95,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "scrolled": true,
     "ExecuteTime": {
@@ -103,7 +121,26 @@
      "end_time": "2023-10-23T14:57:15.782454Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset already exists locally. Reading from local cached zip.\n",
+      "Unzipped folder found in the local cache. Reading from it...\n",
+      "{0: (-97.4745, 35.266), 1: (-97.4745, 35.2626), 2: (-97.4873, 35.2626), 3: (-97.4873, 35.196), 4: (-97.4836, 35.196), 5: (-97.4369, 35.196), 6: (-97.4838, 35.2509), 7: (-97.5113, 35.2509), 8: (-97.5023, 35.246), 9: (-97.4903, 35.2567), 10: (-97.4964, 35.2604), 11: (-97.49950726683866, 35.2427), 12: (-97.4691, 35.2427), 13: (-97.47226381921406, 35.246689303630674), 14: (-97.48874482954297, 35.23152065345497), 15: (-97.4888, 35.2165), 16: (-97.4768, 35.2165), 17: (-97.4888, 35.2101), 18: (-97.4601, 35.2509), 19: (-97.46507448011698, 35.25914896023397), 20: (-97.4442, 35.259), 21: (-97.4466, 35.2406), 22: (-97.4466, 35.2305), 23: (-97.4691, 35.2312), 24: (-97.3976, 35.2045), 25: (-97.3964, 35.2311), 26: (-97.40211901205474, 35.23360380241095), 27: (-97.4021, 35.2561), 28: (-97.4112, 35.2398), 29: (-97.41233569457059, 35.21449438614856), 30: (-97.43521617501703, 35.215086558444916), 31: (-97.4656664519788, 35.21571961356189)}\n",
+      "DiGraph with 32 nodes and 30 edges\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": "<Figure size 640x480 with 1 Axes>",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAApQAAAHzCAYAAACe1o1DAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAABfEklEQVR4nO3de3hU1d328XvPDAkkIJpAUJSASOCpKT5qG6EoYiqgVRuL+igtoCIqWqiKRUVsOSm04gGt1iMeKmLxBBaLVURToIJpak95o5JQJIOCpEkUIRMmzOH9AycSksAks/fsPTPfz3X1qmQme689p9yz1m+tZYTD4bAAAACADnLZ3QAAAAAkNgIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJgQKAEAABATAiUAAABiQqAEAABATAiUAAAAiAmBEgAAADEhUAIAACAmBEoAAADEhEAJAACAmBAoAQAAEBMCJQAAAGJCoAQAAEBMCJQAAACICYESAAAAMSFQAgAAICYESgAAAMSEQAkAAICYECgBAAAQEwIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJgQKAEAABATAiUAAABiQqAEAABATAiUAAAAiAmBEgAAADEhUAIAACAmBEoAAADEhEAJAACAmBAoAQAAEBMCJQAAAGJCoAQAAEBMCJQAAACICYESAAAAMSFQAgAAICYESgAAAMSEQAkAAICYECgBAAAQEwIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJh47G4AgEOr9we0tbZejYGQ0jwu9cvOVGY6b10AgHPwVwlwoMqdu7W0xKviTdXy1vkUPuA2Q1JuVoYKB+Vo3JBc5fXqZlczAQCQJBnhcDh8+LsBiIdtdT7NXFGm9Ztr5HYZCobafntGbh8+oIcWjBmsPlkZcWwpAADfIFACDrGs1KvZK8sVCIUPGSQP5nYZ8rgMzS3K19iCXAtbCABA6wiUgAM8XFype1dXxHyc6aMHamphngktAgAgeszyBmy2rNRrSpiUpHtXV+jFUq8pxwIAIFoESsBG2+p8mr2y3NRjzlpZrm11PlOPCQDAoRAoARvNXFGmQDvqJaMRCIU1c0WZqccEAOBQCJSATSp37tb6zTXtmoATjWAorPWba7S5erepxwUAoC0ESsAmS0u8crsMS47tdhl6/n1qKQEA8UGgBGxSvKna9N7JiGAorOKKakuODQDAwQiUgA32+APyWjxxxlvrU70/YOk5AACQCJSALapq62X1ArBhSVtr6y0+CwAABErAFo2BUFKdBwCQ2giUgA3SPPF568XrPACA1MZfG8AG/bIzZc387m8YX58HAACrESgBG2Sme5SblWHpOXKzM5SZ7rH0HAAASARKwDaFg3IsXYeycGCOJccGAOBgBEokpHp/QOXbd+kf3i9Uvn1XQi6PM25IrqXrUI4fmmvJsQEAOBjjYUgYlTt3a2mJV8WbquWt8zVbdseQlJuVocJBORo3JFd5vbrZ1cyo5fXqpuEDemjDllpTg6XbZWhY/2wNyHH+YwAASA5GOBy2ejk8ICbb6nyauaJM6zfXyO0yDhm+IrcPH9BDC8YMVh+L6xRjta3Op5GL1spv4vI+6R6X1kwb4fhrBwAkD4a84WjLSr0auWitNmyplaTD9uRFbt+wpVYjF63VslJn72fdJytDc4vyTT3mvKJ8wiQAIK4IlHCsh4srNWN5mfyBULuHhIOhsPyBkGYsL9PDxZUWtdAcYwtydcaAbFOOdcaAHrqsgNpJAEB8ESjhSMtKvbp3dYUpx7p3dYVedHBP5bJSr/6yudaUY/1lc42jrxUAkJwIlHCcbXU+zV5ZbuoxZ60s17Y6n6nHNEMqXSsAIHkRKOE4M1eUKWDycjqBUFgzV5SZekwzpNK1AgCSF4ESjlK5c7fWb64xfX3GYCis9ZtrtLl6t6nHjUUqXSsAILkRKOEoS0u8lu4e8/z7LesLw+Gw1qxZo7ffftuS87bFjmsFAMAKBEo4SvGmakt3jymuqG76dzgc1ttvv62hQ4dq1KhRuu666yw5b1viea0AAFiJQAnH2OMPyGvxZBJvrU979u5rCpKjR4/WBx98IEkKBoOWnvtA8brWRNySEgCQeNh6Ec3U+wPaWluvxkBIaR6X+mVnKjM9Pi+Tqtp6Wb1tU1hS3qnD9PlHf2v6WSRI7ty5U2effbbFLdjPn9FT4W9PsPQcYUlba+uV37u7pecBAIBACcfskd1o4vaDh9Kt+1H6XJJhGDpw51GXy6WcnJy4tGF3WrY+jcN54vWYAgBSG4EyhUWzR3ZYUlWdT0tKqvTsxq2W7pGd5olPBcaKV19W484tmjNnjlauXCmPx6NAIKCePXvq97//fVzaUL59l85/6C+WnydejykAILXx1yZFOXGP7H7ZmbJmzvM3jK/Pc8opp+gPf/iD/v73v+u8886TJKWnp1t89m/E81oBALAaPZQp6OHiyg5vaxgMhRUMhTVjeZlq9vg1tTDPtHZlpnuUm5WhKgsnq+RmZzSrCY0Ey3/9619qbGy07LwHs+NaAQCwCj2UKcbpe2QXDsqxdG3GwoGt10j+7//+rwoKCiw5b1vsulYAAMxGoEwhibBv9LghuZauzTh+aK4lx+6IZLzWen9A5dt36R/eL1S+fRfLFgFAimA8LIVYuW/0kklDTDleXq9uGj6ghzZsqTU1bLldhob1z9aAHOtmqbdXslyrU1YJgL3LfgFIbUb4wHVTkLQqd+7WqAfWWXb8NdPONC3AbKvzaeSitfKbuORNuselNdNGWDI7PRaJfK3RrBIQEbndylUCUhWBHoATMOSdIhJp3+g+WRmaW5Rv2vEkaV5RviNDTKJeqxNXCUg12+p8mvBUiUY9sE5LSqpUdVCYlJov+zXqgXWa8FSJqSUqABBBoEwRibZv9NiCXE0fPdCUY90yepAuK3BO7eTBEu1aHy6u1IzlZfIHQu1+TQVDYfkDIc1YXqaHiystamHyI9ADcBoCZQpI1H2jpxbm6dcXDVa6x9Xu3lW3y1C6x6W7LxqsKYUDTG2XFRLlWp2+SkAqINADcCICZQqI1x7ZW2vrTT/u2IJcrZk2QsP6Z0vSYcNW5PZh/bO1ZtoIR/dMHszp15oIqwQkOwI9AKdiUk4K+If3C415dIPl51lx/TCdknuUZcdvmnxQUS1vbSuTD7IzVDgwR+OH5jpqNndHOPFaJzxVYtmMdLNWCUhmiTyBC0DyI1CmgHjtG73qZ2cov3d3y88j7V8e5ZKJ16uhMaDf/uaBpF4exQlLwSTSKgHJikAPwMkY8k4BybhvdGa6Rxn+OmX4diq/d/ekDZPS/mvN791dp+QeZdu1JtIqAcmocudurd9cY/rEumAorPWba7S5erepxwWQegiUKSCyb7SV2Dc6uSXaKgGJxufzac2aNQoEWp/YRqAH4HQEyhTBvtHoqERdJSCRvPrqqxo1apQGDRqkF154QcFgsNntBHoATkegTBHJuG804iNeqwT85V+b9Mknn6iqqkrbtm3TZ599ps8//1zV1dWqqalRXV2dvvzyS3311Vfas2ePfD6f/H6/9u3bp2AwqEQuB29oaJAkffLJJxo3bpxOPPFEvfzyywqFQgR6AAmBMcoUYeW+0QW5R+iEnl1NOyacpdHEWcWHUvSji9S4I/YlcVwul1wul9xud9N/t/a/Q90ey+925BgVFfuvOxKKKyoqdOmllyorK0u/emxJ3Jb9itekOgDJh0CZQhaMGayRi9aaGijDwYBeve0SZdy0S/n5+crPz9egQYM0aNAgFRQUKDf30D2XTpjBjENL88RnIOOJRx/RcV2lUCjU7H/BYLDFzzpyHzOO1dZth/qdQCBw2ONt37691cekrq5O5R9tkmTOTkqHEq8vDgCSE3+5U0hk3+gZy8tMO+aNpx+jm+/5r/aGQvrggw/0z3/+U5IUDAZ15JFH6osvvmjxO01rLG6qlreulTUWszJUOChH44bkKq8XS8nYLbJKgJW9ZIakS84dkbJfJh566CHdeOONCofDcrvdcrvduu6663TrrbfqS6Or/hCHZb/i9cUBQHJKzU/vFDa2IFc1e/ym7LZxy+hBmlI4QJ/efLPuu+8+hcPhpskEhmFoypQpze6/rc6nmSvKtH5zjdwuo9We0rCkqjqflpRU6dmNWzV8QA8tGDOYhZdtFFkloMrCOr5UXyUgHA4rHA6rc+fOmjJliqZPn66jjz5aknSkPxCXQB/PZb8AJB++kqYgs/eNvv3229W1a/Mayp49e2rGjBlN/15W6tXIRWu1YUutJB122D1y+4YttRq5aK2WsUWcrVglwFoXXXSRFi1aJK/Xq3vvvbcpTEos+wW0V70/oPLtu/QP7xcq376LCWdxwidIihpbkKvTT+hx2B7DiMjtw/pnt+gxzMrK0syZMzVz5kyFw2F5PB7V1dXpjDPO0NKlS1VcndbhHtFgKKxgKKwZy8tUs8evqYV5HToOYjNuSK6e3bjVkmOzSoB03HHH6aabbmrz9sJBOVpSUmXJSg0EeiQDSqnsx9aLMGXfaJ/Pp+OPP17V1dV64oknVFBQoHHjxqnuqP9R+vCrTGvr3RcN1mUF+8PHxRdfrIaGBr3xxhumHR9tY+s/+7D1JdC6aEqpIiK3U0plDQIlmoll1vWbb76pdevWaf78+TIMQ5Xb63T+IxvVGDz870Yr3ePSmmkj1Ccrg0AZZ9vqfBq5aK38Js4GPvD5xKER6IHmlpV6NXtluQJfj2RFy+0y5HEZmluUr7EFqT06YiZqKNFMLPtGn3vuuVqwYIEMY3+t3bw/VSoYNrfuLhAKa+YK82apI3qRVQLMNK8onzAZpQVjBstjch2rx2VowZjBph4TiIeHiys1Y3mZ/IFQu79kBUNh+QMhzVhepoeLKy1qYeohUMISlTt3a/3mGtNrvoKhsNZvrtHm6t2mHhfRGVuQq+mjzVkT8ZbRg5rKF3B4BHpgv2WlXlNWKpGke1dX6EUmfZqCQAlLLC3xWjor+Pn3+QCwi9mrBCB6BHqkum11Ps1eWW7qMWetLNc2i7c3TQUESliieFO1pXuHF1dUW3JsRGdsQa7WTBuhYf2zJemwwTJy+ynHZOjtm84kyMSAQI9UNnNFmQIm/22hlMocLBsE0+3xB+S1+Nuet9anowxevnbqk5WhJZOGRL1KwDkDMjQsv7+qfvddvfXWW8rKyrKr6QnPzGW/gEQRKaUy24GlVKx20HHM8obpyrfv0vlx2CruW1WvyfjyM2Z5O8ihVgn49NNP1adPH0lSr1699PLLL2v48OF2NjcpmLHsF5AI5qwst3Q91glD+mqOyXXKqYQuHpiu0cRlZQ4lbLhlTZUmOiqySkBrPJ5vPm6qq6s1YsQIzZ49W3fccUez29A+eb26aU5RvuYoP6ZlvwCni0cp1RwRKDuKGkqYLs0Tn5eVETZxgUtYzu12N/13ZO/quXPnasSIEfL5KIg3QyzLfgFOFq9SKrZp7DgCJUzXLzvT8p5DQ1J641cWnwVmaq0X0jAM/b//9/9UU2N+XRSA5FFVWy+r6/PCkrbW1lt8luRFoITpMtM9yrW46D83O0PuMN8kE8mBgTKy+P0tt9yiqqoq5eYy6xtA2+JVShWv8yQjAiUsUTgox9J1KAsH5lhybFinU6dOcrlcSktL01VXXSWPx6OsrCwdeeSRdjcNgMPFq5QqXudJRjxysMS4IbmWFk+PH0qPVqLp3Lmz1qxZo08++USLFy/WNddco7vvvlu7du2yu2kAHC5epVT9sjMtPkvyIlDCEnm9umn4gB6m91K6XYaGD+jB8icJqrCwUL1795Yk3XHHHfL5fFq0aJHNrQLgdPEqpWIiW8cRKGGZBWMGy2NyoPS4DC0YM9jUY8Iexx57rH7605/q/vvvV21trd3NAeBwlFI5G4ESljm6Wyed23O3qcecV5TPLh9J5LbbblMoFNLChQvtbgoAh6OUytkIlDBVOBzWxo0bNWXKFB111FH6zY2XKa/hY1OOfcvoQewBnWRycnJ000036aGHHtKOHTvsbg4AB6OUytkIlDDFp59+ql/84hfq27evhg0bpscee0z19fvX83rw2h/o1xcNVrrH1e4PArfLULrHpbsvGqwphQOsaDpsNn36dKWnp+tXv/qV3U0B4HCUUjkXgRKmmDlzpubPn69t27ZJkkKh/Wt5nXDCCTrxxBM1tiBXa6aN0LD+2ZJ02GAZuX1Y/2ytmTaCnskkduSRR2r69Ol6/PHH5fV67W4OAAfrk5WhuSbvt00plTkIlDDFggUL1L9/f7lc37ykPB6P/u///q/p332yMrRk0hC9fdOZmjCkr/pmZ7RYBsKQ1Dc7QxOG9NWaaWdqyaQhvNFTwI033qgjjjhCd955p91NAeBwYwtyNX30QFOORSmVeYxwOGz1bkZIEa+//rouvPBCHfiSev/99zVkyJA2f6feH9DW2no1BkJK87jULzsz6mUbLr74YjU0NOiNN96Iue2w3/33369bb71VH330kfLy8uxuDgCHW1bq1eyV5QqEwu2arON2GfK4DM0ryidMmohACVP87W9/09lnn638/Hzt2rVLH374oXr27KnPP/+8Wa+lmQiUyaWhoUEDBgzQWWedpaVLl9rdHAAJYFudTzNXlGn95hq5XcYhg2Xk9uEDemjBmMGMfpmMFTwRs3//+98aPXq0TjzxRL311lsKBAK65JJLNGLECMvCJJJPly5d9Mtf/lI//elPdfvtt+vb3/623U0C4HCRUqrKnbu1tMSr4opqeWt9OjBWGtq/aHnhwByNH5rLbG6L0EOJmHz88cc688wzddxxx+ndd9+N677M9FAmn8bGRg0aNEinnHKKli9fbndzACSgen9Aw865UB9XbNbbb/1J3xmYyw44cUD3ETrsP//5j84++2z16tVLq1evjmuYRHJKS0vTnDlztGLFCn3wwQd2NwdAAvqsaov+vfYNNe6o0IqnHyJMxknK91DGMikklXm9Xg0fPlydO3fW2rVrdfTRR8e9DbH0UPK8O1cgENC3v/1tHX/88frTn/7U9HOeMwDRmDBhgl544QWFQiGlpaWpqqrKlr9RqSYlP42bai02Vctb10qtRVaGCgflaNyQXOX1otbiYNu3b9f3v/99ud1uvfPOOwnzRuV5Twwej0fz5s3TZZddphXvvq9/7enGcwYgKhUVFVq6dGnTaiPBYFALFy7U/fffb3PLkl9K9VAyGyx21dXVGjFihPbs2aP169erX79+trUl2h5KnvfEU1WzRz++f6W2h7vznAGI2oQJE7Rs2TIFAoGmn6Wnp2vr1q0J0/mRqFKmhnJZqVcjF63Vhi21knTYNasit2/YUquRi9ZqWSk7eNTV1WnUqFH68ssv9e6779oaJqPF8554lpV6NfrB9dppHCmJ5wxAdD777DO98MILCgaDTSuMuN1u+f1+/fa3v7W5dckvJYa8Hy6u1L2rKzr0u8GvF0ydsbxMNXv8mlqYmgsu79q1S+ecc462b9+uP//5zwmx8DTPe+LhOQPQUd26ddPUqVO1e/du/fOf/9THH3+ssWPHKhwOa8SIEXY3L+kl/ZD3slKvZiwvM+14d180OOVW1t+zZ4/OOeccffjhh3r33Xd1yimn2N0kSYce8uZ5Tzw8ZwDMcuedd+qRRx7Rjh077G5KykjqIe9tdT7NXllu6jFnrSzXtjqfqcd0soaGBhUVFamsrExvvvmmY8LkofC8Jx6eMwBIbEkdKGeuKFOgHft7RiMQCmvmCvN6UZzM7/froosuUklJiVatWnXIPbmdhOc98fCcAUBiS9pAWblzt9ZvrmnXhvHRCIbCWr+5Rpurd5t6XKfZt2+fxo4dq+LiYv3hD3/Q8OHD7W5SVHjeEw/PGQCzJXk1nyMlbaBcWuKV22VYcmy3y9Dz7zefSRoOh/Xaa6/p/PPPV3m5uUN38RYMBnX55Zdr1apVevXVVzVy5Ei7mxS1eD/vOLyXXnpJY8eObXPnG54zAFYwDGs+V9C6pA2UxZuqTe/xiAiGwiquqJb0TZA86aSTNGbMGL3xxhv629/+Zsl54yEUCunqq6/Wyy+/rGXLlun888+3u0ntEq/nHdF7++239eKLL+q73/2uLrjgghbBkucMABJfUi4btMcfkNfiYnxvrU/PvfCi7p4/Tx9++GHTmlfS/tpDny/xJgOEw2FNmzZNv/vd7/TUU0/p3HPPdfR1BAIBBYPBpjbWx+l5/++XXykzLSnfOpYIBALyeDwKBAJ68803tWrVKp177rmaNWuWBp9aEJfnrN4fYJtGALBQUi4bVL59l85/6C+Wn2f70z/TvupPLD8PotMp53j1vuohy8/D826eRc+8rAc2dbH8PKt+dobye3e3/DwAnGHevHl67LHHtH37drubkjKS8it7YyAUl/Oc+t3T9Nc/bZVhGAqFvjnnddddpzPPPDMubTDLSy+9pNdee01XXnmlRo8ebXdzorJo0SI1NjbqtttukyR5fW49utn689654NfKzQhaf6Ik8eSTT2rt2rVN7xHDMJSWlqYLL7xQQ08/Q9rUem2lmeL1mQAAqSopA2WaJz6loU89+bjSfXfprrvu0pIlS2QYhoLBoIYOHaof//jHcWmDGebPn6/XXntN99xzj6ZPn253c6L2yiuvqKGhoemxLt++S4/GoWf6gh+cQ29XO7z77rv685//LJfLpS5duujnP/+5brrpJh111FEq374rLm2I12cCAGdIwsFXx0vKT9l+2Zmyem6X8fV5BgwYoGeffVabNm3S+PHj5Xa7lZOTY/HZzXP//ffrF7/4hebNm5dQYbI18XzeEb2cnBxlZmbqF7/4hbZt26a5c+fqqKOOksRzBsA6zPKOr6QMlJnpHuVmZVh6jtzsjGZF/pFguWfPHp177rmWntssjzzyiH7+85/r9ttv1y9+8Qu7mxMzO553HN68efNUW1vbLEhG8JwBQHJIykApSYWDcixd265wYOu9kJ07d06Ib0XPPPOMpkyZohtvvFHz589PiDZHw67nHW1zu91KS0tr83aeMwBIfEkbKMcNybV0bbvxQ3MtOXY8/P73v9ekSZM0efJkLVq0KGnCpMTznoh4zgAg8SVtoMzr1U3DB/QwvecjHAyox77/qmd6Ys4aXbFihSZMmKAJEybokUceSaowKVn3vLtdhoYP6KEBOd1MPS54zgCYj0k58Ze0gVKSFowZLI+Jf6TC4bDchlT5wjx961vf0vLly007djy88cYbuuyyy3TxxRfrqaeearYYezIx+3mXJI/L0IIxg009Jr5hyXtVYZ4zIIUlW4eJ0yVnovhan6wMzS3KN+14hmHov2/+Vv933vd16qmn6uKLL9aYMWP06aefmnYOq7zzzju66KKLdN555+n555+Xx5O8kxTMft4laV5RvvpYPHkklVnxXq19+zGV/3WdaccEALQtqQOlJI0tyNX00QNNOdaXa5/Tj07qpWeffVZ79+7V008/rffff18nnniifvvb3yoYdOZi13/5y19UVFSks846Sy+++KI6depkd5MsZ+bzfsvoQbqswPl1ePX+gMq379I/vF+ofPsu1fsDdjepXcx8zm4sPF6nH23oggsu0LPPPmvKMQEAbUvebqoDTC3MU4+u6Zq9slyBULhdEwDcLkMel6E5PzxRxbXdtXjxYt16661avHixtmzZoldeeUVLlizR1KlT9fzzz+uJJ57Q4MHOGWb761//qvPOO0+nnXaali9frvT0dLubFDdmPO/zivIdHSYrd+7W0hKvijdVy1vn04FXaEjKzcpQ4aAcjRuSq7xezq8lNPM5+9n3l2vKlCmaOHGitm3bpl/84hcMgQGARZK+hzJibEGu1kwboWH9syXpsBMAIrcP65+tNdNG6Men9dVjjz2mq6++WgsXLtTtt9+uI444Quecc45GjRqldevW6csvv9Spp56qO+64Qw0NDZZf0+H885//1DnnnKNvf/vbev3115WRkXpDtrE+704Nk9vqfJrwVIlGPbBOS0qqVHVQmJSksKSqOp+WlFRp1APrNOGpEm2r89nR3HYx6znzeDx67LHHdOedd2rWrFmaPHmyAoHE6rUF0DFMyok/I5yCj3pTr05Ftby1rfTqZGeocGCOxg/NbTFDNBQK6brrrtPixYv12GOP6Z133tFLL72kX/7yl7r99tu1cOFCzZ8/X/369dPjjz+uwsLCpt/1+XwqLy9XQUGB5df44YcfasSIEerbt6/eeecdde+efFsFXnzxxWpoaNAbb7wR1f1jed6dZFmpN6YevLlF+Rrr0KB8MLOes2eeeUbXXHONfvCDH2jZsmXKzGTnHCCZzZ49W08//bS2bdtmd1NSRkoGygPV+wPaWluvxkBIaR6X+mVnHnZXjQND5dNPP60dO3bojjvu0A9/+EMtWbJEn332ma699lr95S9/0cSJE3XPPfcoOztbP/7xj7Vs2TJt3LhRQ4cOtayNlZWVOvPMM9WzZ08VFxcrOzs76nMlkvYGygPV+wM68bQR+vy/NfrTqtc15MT+CbGbysPFlbp3dUXMx5k+eqCmFuaZ0KL46ch79UBvvvmmLrnkkqYe+549e1rYWgB2IlDGn/P/glosM92j/N7t671zuVx67LHHJElXXXWVnnnmGb3++uv6yU9+oqFDh+q1117T2rVrm+ot//jHP+qqq67SsmXLZBiGJk+erL///e9yu91tnqOjtXFbt27V2WefrSOPPFJr1qxJ2jAZq3+Uvi/vvzdIkl5+YpG+/+ijNrfo8JaVek0Jk5J07+oK9eya7tgh/dZ05L16oHPPPVdr167Veeedp2HDhunNN9/UCSecYGILASB1pUwNpdkiofLqq6/WxIkTVVNTo7/+9a8KhUI67bTTtHr1al177bX66KOPdPrpp+vuu++WtL+u49///rcef/zxVo8bS23cZ599prPPPludOnXSmjVrlJPDlnNtmTVrVtMEjcWLF8vr9drcokPbVufT7JXlph5z1sryhKipNNN3vvMdbdy4UYZh6Hvf+55KS0vtbhIAJAUCZQwODpXvv/++SkpKdMYZZ+i8887TwoULdfTRR6t///4tZpfedtttqq6ubvazZaVejVy0Vhu21ErSYevjIrdv2FKrkYv+rBFXzdS+ffv07rvv6thjjzXxSpPLhg0bVFxc3FS0HQ6HNX/+fJtbdWgzV5QpYPL2hIFQWDNXlJl6zETQv39/bdiwQSeccILOOuusDpVMAHC2FK/mswWBMkYHh8rXXntNf/jDH3T77bfrtttu0w9/+EPdf//9LV7ce/bs0dVXX93074eLKzVjeZn8gVC79zUOhsLyB8IKnHqpJt3/svr27WvKtSWrWbNmNSs3CAaDevrpp1VVVWVjq9pWuXO31m+uMX2/62AorPWba7S5erepx00EPXr00DvvvKORI0eqqKhITz/9tN1NAmAylgmLLwKlCQ4Olc8//7zmz5+vl156Se+++666deumfv36qWvXrs1+7/XXX9d//vMfU2vjnvmgRi+WOnv41k4VFRV65513FA6Hm7aedLvdCgQCTXWxTrO0xGv6PtcRbpeh599PzddLRkaGXn31VV1zzTWaNGmS5s6dS68GAHRQyk/KMcuBE3UmTpwoSbriiis0cOBA/ehHP9KePXv0xz/+UQUFBdqxY4e8Xq8+/vhjdTryaM1+1tzt4WatLNewE3qwVWArjjvuON13332qr6/Xu+++q7///e+67bbbZBiGioqK7G5eq4o3VZveOxkRDIVVXFGtOTJ3q8pE4fF49Mgjj6hPnz6644479Omnn+rRRx9N6q1JAcAKfGqaqK1QWVpaqksvvVQjR47Ugw8+qOuvv14nnHCCCgsLNeGpEstq45ZMGmLqcZNBRkaGbr75ZklSIBBQZWWlZs6caXOr2rbHH5DX4okz3lqf6v2BhFg2yQqGYWjmzJk69thjdfXVV2vHjh168cUXWasSANqBIW+THTz8/bvf/U49evTQW2+9pZ/+9KeaMmWKrr32Wvn9fmrjbGYYhuOHOKtq61vM8jdbWNLW2nqLz+J8V1xxhVatWqW1a9eqsLCwxaQ5AInD6Z/tyYhAaYHWQmWnTp304IMP6umnn9Zzzz2n73//+3qi+CNq42yUCAXbjYFQUp3H6UaPHq21a9fK6/Vq2LBh2rx5s91NAtBBifAZn0wIlBaJhMpJkyY1hUpp/1D42rVr9cknn+il9eWW18bh0Jz+LTbNE5+3aLzOkwhOPfVUbdy4UW63W8OGDdNf//pXu5sEAI7HXxELuVwuPf744y1C5dChQ7V2Q4mMbtZu/RapjUPrEmHIu192pqz+jm18fR584/jjj9d7772nAQMGqLCwUKtWrbK7SQDgaARKi7UVKhvTjpAs7o6nNu7QEiFQZqZ7lGvxbP3c7IyUnZBzKJG1KkePHq0LL7xQixcvtrtJAOBY/BWJg0iolL6Z/X1SYXyWqKE2rm2JECglqXBQjpaUVFlSHuF2GSocyBadbenSpYteeeUV3XDDDbrmmmv06aefavbs2dRmAcBBCJRxcnCoXPDoc5KOsvy81Ma1LVFCwbghuXp241ZLjh0MhTV+aK4lx04WbrdbDz/8sI477jjNnDlT27Zt02OPPaZOnTrZ3TQAbUiEzoJkQ6CMowND5R03XKs+N78kWVghR23c4SXCh05er24aPqCHNmypNbWX0u0yNKx/tgbkdDPtmMnKMAzdfvvtOvbYYzVp0iTt2LFDL730UovdrwA4R6J0GiQLuq/iLBIqr7p8nPZ98bml56I27tASZchbkhaMGSyPyUtMeVyGFowZbOoxk93ll1+uVatWaf369axVCQAHIFDaIBIq+3f2KRwKWnIOauMOL5ECZZ+sDM0tMnd7xHlF+WzP2QGjR4/WunXr9Omnn+p73/ueKisr7W4SANiOQGkTl8ulxTOukOFyW3L8YCisof2z9A/vFyrfvovlg1qRaMMhYwtyNX30QFOOdcvoQbqs4JvayXp/QOXbd/F6idIpp5yijRs3qlOnTho2bJhKSkrsbhIA2IrxUBsNOrq7zhiQrfcq/6uwYX62v27p35v+25CUm5WhwkE5GjckV3m9qJtLpB7KiKmFeerRNV2zV5YrEAq3q6bS7TIUDgZ09clHaErhAFXu3K2lJV4Vb6qWt87XbItHXi+H169fP7333nsqKipSYWGhXnrpJV1wwQV2NwuAEqM+PtnQQ2mzX405SWmdPJLFL/6wpKo6n5aUVGnUA+s04akSbavzWXrORJCIHzpjC3K1ZtoIDeufLUmH3b4zcvuw/tna9ti1mn3dWA2f9aJGPbBOS0qqVHVQmJR4vUQrOztba9as0bnnnqsLL7xQTzzxhN1NAvC1RBuFSnQESps11cbF6YUf6dHasKVWIxet1bLS1N3vOxF7KCP6ZGVoyaQhevumMzVhSF/1zc5osV6AIalvdoYmDOmrNdPO1JJJQ3TqD36sY65+RN69nSXpsD2cvF4Or0uXLnr55Zd1/fXXa/LkyZo1a1bCvq4AoKMY8naAsQW5qtnj172rK/b3VMYhXAa/Hi6dsbxMNXv8mlqYZ/k5nSaRA2VEXq9umlOUrznKV70/oK219WoMhJTmcalfdmazWf4PF1dqZ7+RMsLhdn9z5/VyaG63Ww899JD69OmjGTNm6NNPP9Xjjz/OWpUAUgaB0iEOrI1r3BewpKayLfeurlDPrunNJmmkgmQbDslM9yi/d/dWb1tW6t3/hUWxX3eqvl4OxzAM3XbbbTr22GM1ceJE7dixQy+//DJrVQJICQx5O0ikNu70vJ6SZNmSQq2ZtbI85WrkkqGHMhrb6nyavbLc1GOm4uslWuPHj9cbb7yh9957T2eddZZ27txpd5OAlJMKn+1OQ6B0mD5ZGXp+0lC9deMZyt27VfvqtkstpkyYLxAKa+aKMsvP4zSp8KEzc0WZAibvA56qr5dojRo1SuvWrdP27dv1ve99TxUVFXY3CUg5yTYK5XQESocadHR3rV00VT8Ilmjb/Zfq+uO/1Irrh+nRcadacr5gKKz1m2u0uXq3Jcd3olTooazcuVvrN9eYumWjlJqvl/Y6+eSTtXHjRqWnp2vYsGF6//33m257+umntX79ehtbBwDmIlA6mMvl0hNPPKGJE36i26+boLI/v66SLXWHXSamo9wuQ8+/nzqzeBM9UIZCIZ177rm69dZb9d///rfV+ywt8fJ6sVHfvn313nvv6X/+53/0/e9/XytXrtQjjzyiSZMm6Zprrkno1x8AHIhA6XCRUHnVVVfpyiuv1Mq//cf03qaIYCis4orU2Zs40YdD/H6/3nrrLd1zzz3Kzc1tNVgWb6rm9WKzrKwsvf322/rBD36gH/3oR5oyZYokadOmTdqwYYPNrQMAczDLOwFEQmXA8Ki40WXpqkLeWp/+U/WpMtKs2RLSTA0NDdq7d6927NjRod//6quvFAqFOvz7dmtoaGj677179+q+++7Tb37zG1111VWaMWOGsnr1ltfiiTPeWp/q/YFmyxOhpS5duuimm27Sa6+91tQr6fF49Nhjj+n0008/5O8ebjkoAHACI8yYS8L4f59+qQt++57l59n+9M+0r/oTy88D6xxxxBHa8JFX5z/0F8vPtepnZ7S5XBH227Jli0499VTt3r1boVCo6eedOnXS559/rqysrGb3Z1tMIDa33367XnzxRW3ZssXupqQMvuYmkH0WDV0e7P4HH9LxCfA3av78+WpsbNTcuXM79PsrV67UM888oxUrVpjcsvjw+/26+OKLm/7tcrkUCoV00kknae7cuWoMhA7x2+aJ13kS2ZYtW+Tz+RQKheTxeBQIBCRJ+/bt05NPPqnbbrtN0v4lnmauKNP6zTVyu4xWyxUO3Bbz2Y1bNXxADy0YM1h9sjLieUmA4yV6WVOiIVAmkDRPfEpeC89MjB6np59+Wg0NDTr//PM79PtbtmyRy+Xq8O/bLTLkHZlcNGLECM2bN09nnHGGJKl8+664tCNer8tENnLkSH3xxRdav3693n77bf3pT3/SRx99JEn61a9+pdtuu03LSr2avbK8aYmn9m6LObcoX2NZbB6ATQiUCaRfdqYMWbsqpfH1eVJBon977dSpk3JycpSfn98sSEbwenGWzMxMnXvuuTr33HN133336fPPP9dzzz2n3bt36+HiyqadjNqLbTERL9Tz4lB4JSSQzHSPcrMyVGXhRIvc7IyU+YBI9GWDPB7PIXdh4fXibEcffbRuvfVWLSv1asZycxaJZ1tMmI16XkSLsaoEUzgox9J1BQsH5lhybCdK9EAZDV4vzsa2mHCqbXU+TXiqRKMeWKclJVWqOihMSs3reUc9sE4TnipxzGsv2T/bnYhAmWDGDcm1dF3B8UNTq2cj2T90eL04G9tiwomWlXo1ctFabdhSK6n99bzLSp2x4UGilzUlGgJlgsnr1U3DB/QwvdfJ7TI0fEAPDchJnSGLVOih5PXiXGyLCSd6uLhSM5aXyR8Itfu1GQyF5Q+ENGN5mR4urrSohXAqAmUCWjBmsDwmBwSPy9CCMYNNPabTpcq3V14vzsS2mHCaZaXeDk8OO9i9qyv0okN6KhEfBMoE1CcrQ3OL8k095ryi/JRbxy4VeiglXi9OxbaYcBLqeRErAmWCGluQq+mjB5pyrFtGD0rJWaGpEiglXi9Os8cfiNu2mEA0kq2eN1U+252EQJnAphbm6dcXDVa6x9XuoTO3y1C6x6W7LxqsKYUDLGqh86XShw6vF+eoqq23dH1Qaf8M3K219RafBckgWet5U6WsySkIlAlubEGu1kwboWH9syXpsEEhcvuw/tlaM21ESvc0peKHDa8XZ2BbTDgJ9bwwAysSJ4E+WRlaMmnINwvQVlTLW9t8zbBwOKzstJCKvnuCxg/NZXauUjNQStG9XgztX7S8cGAOrxcLxGu7SrbFRDTiUc87R+bWccN5CJRJJK9XN80pytcc5TfbIquTy9A9c27VkqcXa9rvfqcBObyxpW8CZTgcTslw2dbrhS3VrMe2mHCKeNbz8pmS3Hh2k1Rmukf5vbs3/fuZJx6TJxzUFVdcIUmaMGGCXU1zjFQPlAc6+PUCa7EtJpwinvW8fMYkNz5tUoTL5dKTTz4pSYTKg6TSxBw4R+GgHC0pqbJkqJFtMRGtZK3n5XM9/giUKYRQ2dyBPZRAvI0bkqtnN2615Nhsi4loJXM9b6qPPMUbgTLFECq/wYcN7BTZFnPDllpTeyndLkPD+mczkQpRoZ4XZmEKYAqKhMqJEyfqiiuu0JIlS+xuki3ooYTd2BYTdovU81qJet7UQKBMUYRKAiXsx7aYcILCQTmWrkNJPW9q4CtDCmP4ez8CJew0tiBXNXv8und1RczHYltMdEQy1vPyuR5/BMoUl8qhkh5KOMXUwjz16Jqu2SvLFQiF21VT6XYZ8rgMzSvKJ0yiQ5K1npc6+fgiUCJlQyUfNnCSsQW5Ov2EHpq5okzrN9fI7TIO+cc9cvuw/tlaMGYww9yIyYIxgzVy0VpTA6XHZWjWD/JMOx6cjUAJSakZKumhhNOwLSbsEqnnnbG8zLyDfvCSBh57ngYNGqTCwkKddtppKigo0Le+9S253W7zzgNHIFCiSaqFSgIlnOrgbTGffvl1Tb91hv78zhqd1P8YZszCEmbX8351xEDN/JO0adMmbd68WY899pgkqUuXLpo3b56mT58e83ngHHwqoZlUC5USgRLOlpnu0bEZYTXuqNCgXuyxDmuZWc/bePrP9eCDD2rnzp0KBoNN92toaFC3btb2rPO5Hn8sG4QWUmVJIXooAaClsQW5WjNthIb1z5akwy4pFLl9WP9srZk2omlyWFpamm677bYW9eqXXnqprr32Wgta3hx18vHFV120KhV6KvmwAYDWmVXPe80112jOnDn66quv5HLt78P64IMP9NFHH+nEE0+Mz8UgLgiUaFOyh0p6KAHg0A6u5z3xtBH6wQ+L9LOfXqd+2YcvwejatatuuOEG3XXXXerWrZtee+01/exnP9OQIUP07LPP6uKLL47TlcBqDHnjkA4e/n7++eftbpJpCJQAEL3MdI982yvUNzOk/N7do67nveGGG/S9731Py5cv11lnnaWNGzfqBz/4gS655BLdfvvtzeorkbjoocRhRUJlOBzW5ZdfLkkaP368za2KHYESANrH5/MpI6N9a5727NlTGzZsaPp3165d9eKLL6qgoEAzZszQ3//+d/3+979XVlaWae3kcz3+CJSIisvl0uLFiyUpqUKlxAcPAEQjHA53KFC2xjAM3XLLLTr55JM1duxYffe739Xy5ct18sknx97QA86B+GHIG1GLhMorr7xSl19+ecIPf/NhAwDR27t3rySZEigjRo0apQ8++EDdu3fXsGHD9MILL5h2bMQXPZRol2TqqWTIGwCi19DQIMncQClJ/fr103vvvafJkydr3Lhx+tvf/qaFCxfK4yGiJBKeLbRbsoRKAiUARM/n80kyP1BGjvncc8+poKBAN998s/7xj3/oxRdfVE5OjunngjUY8kaHJMPwN4ESAKIXCZRdunSx5PiGYeiGG27QO++8ow8//FDf+c53VFpa2u7j1PsD+tLoqtBRuSrfvkv1/oAFrcXB6KFEhyVLTyWBEgAOz8oeygONGDFCH3zwgS6++GINHz5cjz76qCZOnHjI32lagH1Ttbx1PoU7nSaNOE3nP/SX/QuwZ2WocFCOxg3JVV4va7d9TFUESsQkkUMlk3IAIHrxCpSSdNxxx2nt2rX62c9+pquuukqlpaV64IEHlJaW1ux+2+p8mrmiTOs318jtMlrdezwsqarOpyUlVXp241YNH9BDC8YMVp8s668jlRAoEbNEDZUMeQNA9OIZKCWpc+fOevLJJ1VQUKCpU6fqX//6l1555RUdc8wxkqRlpV7NXlmuwNchsrUweaDI7Ru21GrkorWaW5SvsV/vO47YEShhikQMlQRKAIhevANlxLXXXqvBgwfr4osv1ne+8x298sor+ru/p+5dXdGh4wVDYQVDYc1YXqaaPX5NLcwzucWpiUAJ0yRaqCRQAkD07AqUkvS9731PH3zwgf7v//5P5/3sLh05eoopx713dYV6dk3XZfRUxoxACVMlWqiUCJQAEI3IOpRWzfI+nGOOOUa/e3WVznlgncyctz1rZbmGndCDmsoYEShhukQJlUzKAYDo+Xw+paWlye1229aGOX/8WGGXWzpMvWR7BEJhzVxRpiWThph2zFREoIQl2gqVgUBAd911ly644AJ997vftbOJDHkDQDuYtY93R1Xu3K31m2tMP24wFNb6zTXaXL1bA3JYUqijCJSwzMGhMhgM6o9//KNeeeUVlZaWatWqVba2j0AJANGzO1AuLfG2uTRQrNwuQ8+/79WconzTj50qCJSwVCRUhkIhXXnllU0hbvXq1dq1a5e6d+9uW9sIlHCyUCikM844Q5999lnTZIj//d//lcvl0sUXX6z777/f5hYi1dgdKIs3VVsSJqX9vZTFFdWaIwJlR7H1IiwXCoVUX18v6ZvwFggEtHLlSjub1YRACScyDEP//e9/5fV6VVOzf5jv008/ldfrbXo/AfFkZ6Dc4w/IW+ez9BzeWh/bNMaAQAnL/fznP9crr7zS7Gcul0vLli075O/V+wMq375L//B+Ycl+rEzKgZMZhqG5c+e2+Lnb7dbMmTNtaBFSnZ2Bsqq2XlZ/9Q9L2lrLl7WOYsgbljvppJPUu3dvbd++XR6PR4FAQKFQSG+99VaLYe8W+7EecJyD92ONFUPe36j3B7S1tl6NgZDSPC71y85UZjofD3a77LLLNGvWLG3ZskXhcFhut1tXXXWV+vbta3fTkIJ8Pp9tSwY1BkJJdZ5kxF8MWG7SpElNe7G+9NJL+v3vf6/t27crGAzqwQcf1KxZszq0H2u3Y0erl/fdDrcr1QNle8J7Xi9mPtrB7XZr3rx5GjduXNPP7rjjDhtbhFTW0NBgWw9lmic+A6rtOQ9fxJtL3StHXBmGodNOO02nnXaa7rnnHpWUlOjOO+/UiBEjOrwf6+6M3toz6CdaVurt0H6sqRooOxLehw/ooQVjBrPwrw0uu+wy3Xzzzdq5c6fGjRtH7yRs4/P5dOSRR9py7n7ZmTIkS4e9ja/Pcyh8EW8bNZSIO8MwNHToUK1atUplod6asbxM/kCo/bP3DJfChlszlpfp4eLKDrcnlQLlslKvRi5aqw1baiVFH943bKnVyEVrtazUa3kb0Zzb7dZNN90kwzConYSt7KyhzEz3KNfiL7S52Rlt9jBuq/NpwlMlGvXAOi0pqVLVQWFSav5FfNQD6zThqRJts3gikZMQKGGbZaVe3bu6IraDfN3LeO/qCr3YzrCTapNyHi6u7HB4D4bC8gdCMYd3tF+9P6AfXn69/vqfagW6Hc0sVNjG7mWDCgflyO2y5nPb7TJUODCn1dv4Ih4dhrxhi211Ps1eWW7qMdu7H2sqDXmbEt6/du/qCvXsmq7LOlBmgOgwrAYnsjtQjhuSq2c3brXk2MFQWPnpdSorK5PL5Wr63+///YWe/Xtth48ZDIU1Y3mZavb4NbUwz+RWOwuBEraYuaKsqWbSLO3djzVVAqUTwjuiQ30rnMzuQJnXq5uGD+ihDVtqTV3g3O0y1CNYq0vPvaDZz7ueNFrZ591gyjlS4Ys4Q96Iu8h+rGbveHDgfqzRSJVAaWV4h3kYVoPT2blsUMSCMYPlMXnY2+MytPjas5Wdnf3Nz7r30lGjJpv692HWyvKkrqkkUCLuIvuxWiGyH2t7JHOgdEp4x6FR34pEYHcPpST1ycrQXJP3255XlK/B/XtrzZo18nj2D9xmnTtFhsttaq19sn8RJ1Ai7uKxH2s0UmFSjtPCO1oyu761vZPTgGiEw2Fb16E80NiCXE0fPdCUY90yelDTMPTJJ5+sRYsWqVN2H3U5/lQZbnOrApP9iziBEnHlpP1YU2HI247wvnfvXj333HNav369JedNJlbVtybzsBrssXfvXklyRKCUpKmFefr1RYOV7nG1+0uz22Uo3ePS3RcN1pTCAc1umzJlik66aIrCoaCZzW127mT9Ik6gRFw5aT/WZA+U8Q7vX3zxhRYsWKDjjjtOV1xxhe6++25Lz50MqG9FovD59n+WOCVQSvt7KtdMG6Fh/ffXPh4uWEZuH9Y/W2umjWh1goxhGOp8wndkuNzmN1jtG0VLNMzyRlw5aT/WZA+U8QrvG8oq9fpzj+rJJ59UY2OjQqH9j33nzp0tPntii9S3mu3AYbUBOSwpBHM4MVBK+2sql0wa8s1SWxXV8ta2stRWdoYKB+Zo/NDcQ74v9vgD+uxLv6VtjnwRT7ZtGpPrauB4TtqPNdkDZbzC+wVFP1LjjpY1gOvWrdPo0aPVpUsXZWRkqEuXLk3/O9S/D3Vb586d5XIlx8BKpL7VipKEyLDaHJMnLyB1OTVQRuT16qY5Rfmao/yY9tiO5yhafu/uFp8pvgiUiCun7MeaCuIV3r976sna+EalDMNo6p00DENHHnmkunfvroaGBu3cuVMNDQ1qaGiQz+dr+u/Iv9ujc+fOMQfTaH+3U6dOlk3eikd96xwRKGGOyPvU7mWDopGZ7ulwWHPSKFqiIVAiriL7sVZZWNt3qP1YD5TsPZTxCu+rX12q7d67NGPGDC1fvlxut1vhcFjnnXeeHnjggcMeIxwOy+/3txo4Wwufh7utvr5eNTU1bd63sbEx6utzuVym9rBG/i1PetzqW5NtWA32cHoPpVmcNIqWaPikQdwVDsrRkpIqy4b62tqP9WDJHijjGd7z8vL06quv6v3339fNN9+sjRs3qnv36HoIDMNQ586d1blzZx111FGWtTUiGAw2C6IdDa6R/9XV1emzzz5r876RXtsDdco5Xr2vesjS60zWYTXYI1UCJaNoHUegRNxZvR/r+KHRbW2V7IFSin94Hzp0qN577z299957+p//+R/Tz2kGt9utrl27qmvXrpafKxwOa9++fS3C6L8++0ozi+ssP38yDqvBHg0NDZKSP1A6aRQt0SRfnyscL7Ifq9kLbrtdhoYP6BH1zNZUCJTjhuRaWqfXWng3DENnnHGGevToYcl5E4lhGEpLS1P37t119NFHq3///srPz9f/fvvEuJw/GYfVYI9U6aGU9n8Rt3JDiGhH0RINnzawhVX7sS4YM9jUYyY6p4R3NBcZVrNSsg6rwR6JNCknVnZ8EU8GBErYwqr9WPtkRf/tORV6KCXCuxNFhtWslKzDarCHz+dTenq63G5rFvx2Er6IdwyBErYxZT/Wr8PggfuxRitVAqUTwjtaYlgNicTn86VE72QEX8Tbj0AJW8WyH6vCIRnhYKv7sUYjVQKlZFJ4/1pHwjtaYlgNicTn86VE/WQEX8Tbj0AJ23V0P9Zuvu06YdMLHQ43qRQopdjCu9tlKN3j6nB4R0sMqyGRpFqglPgi3l4ESjhCZD/Wt286UxOG9FXf7IwWkxYMSX2zMzRhSF+tmXamBn62WmmNu+1obsLqaHgf1j9ba6aNSPoPxHhjWA2JIhUDpcQX8fagYhuOcvB+rL955veaM+8ulZZs1Ak5R5g6ySDVeigjIuG9cuduLS3xqriiWt5aX7OFfA3tn9RRODBH44fm0ttlkciw2ozlZaYdM9mH1WCPhoaGlAyU0v4v4qef0EMzV5Rp/eYauV3GIctVIrcP65+tBWMGp8z7kUAJx8pM9+jo9IAad1Qov3d302cXpmqgjDg4vG+trVdjIKQ0j0v9sjOZIRwnYwtyVbPHr3tXV8R8rFQYVoM9UrWHMoIv4ofHXww4mpVhL9UD5YEy0z1s0WejqYV56tE1XbNXlisQCrdrso7bZcjjMjSvKJ8wCcukeqCMOPCL+M7aL3X8SafpiCOz9M7bb6X8F3FqKOFokbAXCX9mIlDCSahvhZOl2rJB0XjkN4vUsL1SOz8s0a6t5SkdJiV6KOFwVgZKwGkYVoNT+Xw+HXvssXY3wzF27NihhQsXStr/92nhwoV67bXX7G2UzQiUSAj0UCKVUN8Kp2HIu7lZs2Zp3759kvb/DVm5cqUqKyuVl5dnc8vsw5A3HI0aSqS6SH3rKblHKb93d8IkbEGg/EZ5ebmeeuopBYPBpp+53W4tWrTIxlbZj0AJRyNQAoD9CJTfuO+++xQOh9WpUydJksvlUiAQ0NNPP62vvvrK5tbZh6+6cLRwOGxZ/SSBEgCik8rrUB7s+uuvV//+/VVfX69f//rXOv3005Wbm6suXbo0hcxURKCEo1kZKAEA0WGW9zcKCgpUUFAgn8+nX//615o8ebLGjRtnd7Nsx5A3HI8eSgCwTygUooeyFT6fT5J4XL5GoISjMeQNAPbau3evJILTwQiUzREo4WgESgCwF8GpdTwuzREo4WjM8gYAexGcWsfj0hyBEo7GpBwAsBfBqXU8Ls0RKOF4DHkDgH0ITq1raGiQxOMSQaCEo1FDCQD2Iji1jqDdHIESjkagBAB7EZxax+PSHIESjkagBAB7RYITC5s3x+PSHIESKYvJPgBwePTEtc7n86lz585yuYhSEoESDhePWd70UAJA2+iJa53P5yNkH4BACUdjyBsA7OXz+ZSeni632213UxyFQNkcgRKORqAEAHsRnFrH49IcgRKORqAEAHs1NDQQnFrh8/koAzgAgRKOZ3WgBAC0jZ641vG4NEeghKPFo/eQHkoAaBvBqXU8Ls0RKOFoDHkDgL0Y2m0dpQDNESjhaARKALAXPXGt43FpjkAJRyNQAoC9CE6t43FpjkAJx2NSDgDYh+DUOh6X5giUcDQm5QCAvQhOreNxaY5ACUdjyBsA7MXkk9YRKJsjUMLRCJQAYC+CU+t4XJojUMLRCJQAYC+WDWodgbI5AiUczcqwx6QcADg8glNLwWBQfr+fx+UABEo4ntXBjx5KAGgbgbKlhoYGSeJxOQCBEo7GkDcA2CcUCmnv3r0Ep4P4fD5JBMoDESjhaARKALAPPXGtI1C2RKCEoxEoAcA+BMrWRR4XJit9g0AJR2NSDgDYh5641vG4tESghOMxKQcA7EFwah2PS0sESjgaQ94AYJ9IcGJotzkCZUsESjgagRIA7ENwah2PS0sESjhaPGooCZQA0DqCU+t4XFoiUMLR4tFDCQBoHcGpdZHHpXPnzja3xDkIlHA8JuUAgD0IlK2L7B5Ex8Q3CJRwNGooAcA+rLfYOrajbMljdwOAg1VVVamoqEi7d+/WF198oT179igvL08ul0u//OUvNX78eFPOQ6AEgEPz+Xzq3LmzXC76nw5EoGyJQAnH6dy5sz7++GM1NjY2/Wzz5s2SpPr6etPOQ6AEgEMjOLWOx6UlvnLAcXr16qXJkyfL7XY3/cwwDB1zzDG68sor7WsYAKQYn8/HcHcrCJQtESjhSDNmzGg2xBIOhzV79mylp6ebdg56KAHg0AhOrWtoaOBxOQiBEo7Uu3dvTZ48uSn0HXvssZo4caKp5yBQAsChEShbx+PSEoESjjVjxoym0Dd79mylpaWZenwCJQAcGsGpdTwuLREo4VjHHnuszjzzTHXp0kVXXHGF6ccnUALAoTG02zpqS1tiljccq94f0ENLVqh+r1+VNQ3ql+1SZnpyvGTr/QFtra1XYyCkNI9L/bIzk+baACQPeuJax+PSEn/B4CiVO3draYlXxZuq5a3z6cC+Q0NSblaGCgflaNyQ3JjPFe8eyvZcW16vbnFpEwAcis/nU48ePexuhuMQKFsiUMIRttX5NHNFmdZvrpHbZSgYahnywpKq6nxaUlKlZzduVbdjR6uX990OnzNegbIj1zZ8QA8tGDNYfbL4wAJgH4Z2W0egbIkaSthuWalXIxet1YYttZLUauA6UOT23Rm99Z9BP9GyUm+HzhuPQNnRa9uwpVYjF63t8LUBQEft27dPH374oT755BPt2rVLHo9HwWDQ7mY5CoGyJQIlbPVwcaVmLC+TPxA6bNhqwXApbLg1Y3mZHi6ubPe5rQ6UsVxbMBSWPxDq8LXFW70/oPLtu/QP7xcq375L9f6A3U0C0EFz585Vfn6++vfvrw8//FCLFy+Wx+PREUccoU2bNtndPEcgULbEkDdss6zUq3tXV8R2kK9D4b2rK9Sza7ouK4i9ttIMplzb15x2bRHUhALJ6eyzz9b8+fNb/NzlcqlXr142tMh5CJQt0UMJW2yr82n2ynJTjzlrZbm21fmivr9VPZROuDYrbavzacJTJRr1wDotKalS1UFhUmpeEzrqgXWa8FSJY9oP4NDOOussnXTSSc12KzMMQ3PmzNGRRx5pX8McIhAIaN++fdSWHoRACVvMXFGmQHuHuA8jEApr5oqyqO9vVaB0wrVZhZpQIPkZhqEZM2YoFAo1/axPnz766U9/amOrnMPn2//lODMz0+aWOAuBEnFXuXO31m+uaX/N5GEEQ2Gt31yjzdW7o7q/FYHSKddmhVSqCYW1qLl1vksuuUS9e/du+vfChQtN360sUTU0NEgSQ94HoYYScbe0xNvm8jmxcrsMPf++V3OK8g97344Eyh07dmjdunX60Y9+pPT09Ba3O+XazJYKNaGwFjW3iaVTp0664YYbNGPGDPXr10+XXnqp3U1yjEgPJYGyOXooEXfFm6otCVzS/p6w4opqS44tSb/73e80duxY9e3bV4888oj8fn+z2xP52tqS7DWhsBY1t4nr2muvVc+ePXXPPfc0fQEHgbItBErE1R5/QF6L/1B4a33tGkJrTw9lMBiUy+XSzp07NXXq1GbB0onXZoZkrgmFtai5TVz1/oC2N7j01t826VvDRlGWcAACZesY8kZcVdXWt+idMFtY0o8mXKMue2ujuv/DDz+s119/Par7VlRUNAXQcDisnTt3asqUKbr55pt1z+LfKyxra4zCkrbW1iu/d3dLzxMRqQk124E1oQNyGN5MRg8XV3a4TCIYCisYCmvG8jLV7PFramGeya1DayhLiA6BsnUESsRVYyB0+DuZIOxyt2uIJtr7tnU/wzAUjFOHf7weQyl5a0JhLWpuEwvbw7ZPJFCybFBzBErEVZonPqHrwfvvi6oXz+Px6Prrr9d1110X1XHnz5+vWbNmNfVSHnPMMZo1a5YmTpyozbV79UD5X2JqdzTi9RhK8akJnaNvAmU4HNYbb7yhRx99VDfddJNGjhxpyblhHatqboed0CMlw4vVlpV6NXtleVNZS3vLEuYW5WtsioV9eihbRw0l4qpfdqasLu02vj6PFdxut0KhkI455hg9+uij+uSTT3TdddcpPT094a/tYPGsCQ0EAnrhhReUn5+vCy64QKtWrdL7779v6blhDWpuEwdLgXUMgbJ19FAirjLTPcrNylCVhUElNztDmenRvbQNw2jXpJwrrrhC/fv314UXXthi2SCnXVus4lXvesu8hVr+1G+0c+fOppICt9stl8ulYDAot9ttcStgFmpuEwdlCR3n8/nkcrlYl/MgBErEXeGgHC0pqbKsLq9wYE7U929voDzmmGMOuR6bk64tVvGq1Xzqmd+pcedOSd/MuA8Gg7rjjjt0xx13NH1wp6WlKT09vem/nfQzj8fDsiqyr+a2oqJC3bp10zHHHGP6eZMRZQmxiezjzXu+OQIl4m7ckFw9u3GrJccOhsIaPzT6b8ntDZSH46Rri1W8ajXHXnqJXnnyAe3du7fZVm9XXnmlzjzzTDU2NqqxsVF+v7/pvw/8X2s/37NnT1T3i/w8GAzGfB12htto7tupU6dmezNbIZ41t+FwWOvXr9eCBQv01ltvady4cXr++ectOXeysbIsYcmkIaYe14kigRLNESgRd3m9umn4gB7asKXW1D8+bpehYf2z2zUkZnagdNK1xSpSE2rlsLch6ZG75+qB2dO1cOFCLVq0SIFAQMFgUGeccYYmTpxo4dm/EQwGtW/fvkOGz/YE2oN/1tZ9vvrqq6iPt2/fvpiv0+PxmBpSD/yZu3OmvHXHmfBstM1b69PuhkateXOV5s+frw8++EBu9/4VHQ78MoK2UZYQOwJl6wiUsMWCMYM1ctFaU0OXx2VowZjBph2vo5Ll2uJZE5qZfpR+9atf6YYbbtC8efO0ePFi9enTx7LzHsztdsvtdqtz585xO2d7hcPhQ4beaENwe3/m8/miOqeR1UdH/XihtY+BpOO+dYq+qvqw6WfBYFCGYej//b//pzlz5qhz587q3Lmz0tPTW/3vQ92Wnp6e9OULLAUWOwJl6wiUsEWfrAzNLcrXjOXmzdycV5Tf7vods3soJedcmxniXRMamT3/m9/8Rh4PH08HMgyjqUfQif7h/UJjHt1g+XlcnpbXHw6HVVVVpcWLF2vv3r3y+/3au3evAoH27+7icrmiCp7RBtSO3K9Tp06Whdp4LwWWjBoaGgiUreATG7YZW5Crmj3+2GYahsOSYeiW0YM6NMPQikApmXRtX+votZnBrprQTp06WXJOWCdeNbdri99R6eoVuuOOO1RdXa1wOCyPx6OJEyfqgQceaHbfYDDYFC4PDJqt/bsj96utrW12vwNvj/x/Y2Njh67TivCqTp3lrbM2CEWWAovXahR2oIeydcn7jCMhTC3MU4+u6U0L67brm3M4JCMc0q8vPqXDgcuqQCnFdm1ulyGPy9C8onxbl+JIpppQWCteNbcn5ByhkyZN0k9+8hM99NBDuuuuu7R79+4Wy3hJ+0sZMjIybP3jHwqF5Pf7ow6p7Qm0e/fu1ZdffnnY+/r9fklSp5zj1fuqhyy93nhvD2sHAmXrCJSw3diCXJ1+Qo/Dbv0VEbm9m2+7ennf1WUFF3b43FYGSqnj1zasf7ZjtjVLlppQWCve67B26dJFt956q6655ho9/vjjOv/88y07byxcLpe6dOli6zZ9oVBIjY2NKv2kRhOe+5fl54vn9rB2IFC2jkAJR+iTlaElk4aocuduLS3xqriiWt5aX7PeDkP7/6AUDszR+KG5uu36K9XQ2GBXk6PWkWtzUs9dMtWEwlp2rMN61FFHacaMGaafL5lE6kKzusfncyWe28PawefzKSsry+5mOA6BEo6S16ub5hTla47yVe8PaPL0X+hfZeVa9sLz6pedaXpdjtU9lAc6+Nq21tarMRBSmsdlybWZKVlqQmGtZFqHNRnFqywhXtvD2oUeytY59y8YUlZtba0efPBB+f1+ffje26r+7DM99+ACSdLll1+u/HzzZhDGM1AeKDPdk3A1RslQEwprUXPrbMm2PaxdCJStS+5nHQnpP//5j+68886mXT3C4bDuv/9+BQIBHXPMMUkRKBNVMtSEwlrU3DpbMm0PaxcCZeuSu9ABCamgoECnnXZa0+4X4XBYgUBAXbt21ZVXXmn6+QiU7ROpCX37pjM1YUhf9c3O0MEr5hmS+mZnaMKQvloz7UwtmTSEMJkiIjW3ZqLm1jzjhuRaug5lKpQlEChbRw8lHMcwDN11110aPXp0089cLpemT5+uI4880vRzoWMSuSYU1qLm1rkoS4gdgbJ19FDCkUaOHNnUSylJGRkZuvHGG00/D0Pe5ojUhJ6Se5Tye3cnTEJTC/P064sGK93jktvVvi9ubpehdI9Ld180WFMKB1jUwtS1YMxgedr5nBxOqpQlhMNhAmUbCJRwpEgvZSTsWdE7GTkPgRKwxtiCXK2ZNkLD+mdL0mGDZeT2Yf2ztWbaCHomLUJZQsft27dPwWCQQNkKuhHgWCNHjlSvXr303//+15LeSYlACVgt0ddhTVaUJXRMQ8P+tY8JlC0RKOFYvsagHnlhpbZu+1Sf+Qx16mLN/rAESsB61Nw6D0uBtZ/Pt3/JJQJlS7yD4ShNvRibquWti/RipOs3H/9lfy9GVoYKB+Vo3BBzPsDooQTiLxHXYU1WLAXWPgTKthEo4Qjb6nyH/UALS6qq82lJSZWe3bhV3Y4drV7ed2M6L7O8AaQ6yhKiR6BsG4EStltW6m0acpF02GGXyO27M3prz6CfaFmpV2M7OORCDyUA7EdZwuERKNvGqwO2eri4suNF4YZLYRmasbxMNXv8mlqY1/5DECgBoAXKEloXCZRdunSxuSXOw7JBsM2yUm/sMwy/HrK+d3WFXiz1dugQBEoAQDTooWwbgRK22Fbn0+yV5aYec9bKcm2r87Xrd+ihBABEi0DZNgIlbDFzRVlTzaRZAqGwZq4oa9fvMCkHABAtAmXbCJSIu8qdu7V+c42p+8hK+yfrrN9co83Vu6P+HXooAQDR8vl88ng86tSpk91NcRwCJeJuaYm33Xv7RsvtMvT8+9HXUhIoAQDRYh/vthEoEXfFm6pN752MCIbCKq6obtfvECgBANEgULaNQIm42uMPyNvOiTPt5a31qd4fiOq+9FACAKJFoGwbgRJxVVVbL6vjW1jS1tr6qO7LpBwAQLQaGhoIlG0gUCKuGgMhR52HHkoAQLTooWwbgRJxleaJz0su2vMQKAEA0SJQto1Aibjql50pqweZja/PEy0CJQAgGgTKthEoEVeZ6R7lZln7ZszNzlBmenTb1NNDCQCIFoGybQRKxF3hoBxL16EsHJgT9f2ZlAMAiJbP51OXLl3sboYjESgRd+OG5Fq6DuX4oblR358eSgBAtOihbBuBEnGX16ubhg/oYXovpdtlaPiAHhqQ0y3q3yFQAgCiRaBsG4EStlgwZrA8JgdKj8vQgjGD2/17BEoAQDQIlG0jUMIWfbIyNLco39RjzivKV592TvihhxIAEC0CZdsIlLDN2IJcTR89MLaDfB0Gbxk9SJcVRF87GcGkHABAtAiUbSNQwlZTC/P064sGK93jan9NZTgkIxzU3RcN1pTCAR06Pz2UAIBohMNhAuUhEChhu7EFuVozbYSG9c+WpMMGy8jt3XzbdcKmFzrUMxlBoAQARKOxsVHhcJhA2QYCJRyhT1aGlkwaordvOlMThvRV3+yMFjvqGJL6ZmdowpC+WjPtTA38bLXSGnfHfG4CJQDgcHw+nyQRKNsQ3XYiQJzk9eqmOUX5mqN81fsD2lpbr8ZASGkel/plZ0a9A0606KEEAESDQHloBEo4Vma6R/m9u1t6DiblAACiQaA8NIa8kdLooQQARINAeWgESqQ0AiUAIBqRQMle3q0jUCLlESgBAIdS7w/o4517lHbMQG33uVTvD9jdJMehhhIpjR5KAEBrKnfu1tISr4o3Vctb51NY0jFX3K9rlm+RsXyLcrMyVDgoR+OG5CqvVze7m2s7AiVSGpNyAAAH2lbn08wVZVq/uUZul6FgqGWnQ1hSVZ1PS0qq9OzGrRo+oIcWjBnc7u1/kwlD3khp9FACACKWlXo1ctFabdhSK0mthskDRW7fsKVWIxet1bJSr+VtdCp6KJHyCJQAgIeLK3Xv6ooO/W4wFFYwFNaM5WWq2ePX1MI8k1vnfPRQIqXRQwkAWFbq7XCYPNi9qyv0Ygr2VBIokdIIlACQ2rbV+TR7Zbmpx5y1slzb6nymHtPpCJRIaUzKAYDUNnNFmQKHqZVsr0AorJkrykw9ptMRKJHS6KEEgNRVuXO31m+uOezkm/YKhsJav7lGm6t3m3pcJyNQIuURKAEgNS0t8crtsmakyu0y9Pz7qVNLSaBESqOHEgBSV/GmatN7JyOCobCKK6otObYTESiR0giUAJCa9vgD8lo8ccZb60uZbRoJlEhpTMoBgNRUVVsvq7sTwpK21tZbfBZnIFAipdFDCQCpqTEQSqrz2I1AiZRHoASA1JPmiU8Eitd57JYaVwm0gR5KAEhN/bIzZXXRk/H1eVIBgRIpjUAJAKkpM92j3KwMS8+Rm52hzHSPpedwCgIlUhqTcgAgdRUOyrF0HcrCgTmWHNuJCJRIafRQAkDqGjck19J1KMcPzbXk2E5EoETKI1ACQGrK69VNwwf0ML2X0u0yNHxADw3I6WbqcZ2MQImURg8lAKS2BWMGy2NyoPS4DC0YM9jUYzodgRIpjUAJAKmtT1aG5hblm3rMeUX56mPxhB+nIVAipTEpBwAwtiBX00cPNOVYt4wepMsKUqd2MiI15rIDbaCHEgAgSVML89Sja7pmryxXIBRu12Qdt8uQx2VoXlF+SoZJiR5KgEAJAJC0v6dyzbQRGtY/W5IOO1kncvuw/tlaM21EyoZJiR5KpDh6KAEAB+qTlaElk4aocuduLS3xqriiWt5anw78S2Fo/6LlhQNzNH5obkrN5m4LgRIpjUAJAGhNXq9umlOUrznKV70/oK219WoMhJTmcalfdmbK7IATLR4NpDQm5QAADicz3aP83t3tboajUUOJlEYPJQAAsSNQIuURKAEAiA2BEimNHkoAAGJHoERKI1ACABA7AiVSGpNyAACIHYESKY0eSgAAYkegRMojUAIAEBsCJVIaPZQAAMSOQImURqAEACB2BEqkNCblAAAQOwIlUh49lAAAxIa9vJFQVq9eraKiIgWDQQWDQUlSp06d5HK59PLLL6uoqKhdx2PIGwCA2BEokVD69OmjxsbGZiEwEAhIknJzc9t9PAIlAACxY8gbCeVb3/qWLrvsMnk833wX8ng8uvDCC3XyySe3+3gESgAAYkegRMKZNWtW03C3tL+Hcs6cOR06FpNyAACIHYESCSfSS2kYhgzD6HDvZAQ9lAAAxIZAiYQ0a9YshcNhhcPhDvdOSgx5AwBgBiblICF961vf0tChQ7V3796YeicNw1AoFDKvYQAApCACJRJSvT+gxa++qcZASOXbd6lfdqYy09v3cq73B+TP6Kl9wXCHjwGgpXp/QFtr69UYCCnN4+K9BaQAI8x4HxJE5c7dWlriVfGmannrfDrwhWtIys3KUOGgHI0bkqu8Xt0sOwaAlnhvAamNQAnH21bn08wVZVq/uUZul6FgqO2XbOT24QN6aMGYweqTlWHaMQC0xHsLgESghMMtK/Vq9spyBULhQ/6hOpjbZcjjMjS3KF+SYj7G2IL2L5oOJDsz3p+8t4DkQKCEYz1cXKl7V1fY3QxJ0vTRAzW1MM/uZgCOYdb7k/cWkBxYNgiOtKzU65gwKUn3rq7Qi6Veu5sBOIKZ70/eW0ByIFDCcbbV+TR7ZbndzWhh1spybavz2d0MwFZWvD95bwGJj0AJx5m5okyBdtRjxUsgFNbMFWV2NwOwlRXvT95bQOIjUMJRKnfu1vrNNe0q8I+XYCis9ZtrtLl6t91NAWxh1fuT9xaQ+AiUcJSlJV65XYbdzWiT22Xo+fep90JyeuWVV/TUU0+psbGx1dutfH/y3gISG4ESjlK8qdqRvZMRwVBYxRXVdjcDsMScOXN09dVX6/jjj9cTTzzRIlha+f7kvQUkNgIlHGOPPyBvAhTme2t9qvcH7G4GYJkdO3Zo8uTJzYJlPN6fvLeAxMXmqnCMqtp6Obdv8hthSaeOOEeuXdvtbgpgqi1btkiSIssTb9++XZMnT9aNN96otf/+j+Xvz7CkrbX1yu/d3eIzATAbgRKO0RgI2d2EqA0bPkLZ4a/sbgZgqmeffVa1tbVN/zaM/fWSp556qlyetLi0IZE+BwB8g0AJx0jzJE4FxvRpN9KLgqTz5ptvqra2Vm63W5J01VVXaebMmerXr5/Kt++KSxsS6XMAwDcIlHCMftmZMiTHD3sb2t9WINlkZGTI7XZr4sSJuuOOO9SvX7+m2+Lx/uS9BSQuAiUcIzPdo9ysDFU5fGJObnaGMtN56yD5vPjii3K73crNzW1xWzzen7y3gMTF2AIcpXBQjuPXoSwcmGN3MwBLHH/88a2GyQgr35+8t4DERqCEo4wbkuv4dSjHD237Dy6QzKx8f/LeAhIbgRKOkterm4YP6OHIXkq3y9DwAT00IKeb3U0BbGHV+5P3FpD4CJRwnAVjBsvjwEDpcRlaMGaw3c0AbGXF+5P3FpD4CJRwnD5ZGZpblG93M1qYV5SvPlkZdjcDsJUV70/eW0DiI1DCkcYW5Gr66IF2N6PJLaMH6bIC6rsAydz3J+8tIDkY4cgeW4ADLSv1avbKcgVC4XZNBnC7DHlchuYV5SssxXwM/uABLZnx/uS9BSQHAiUcb1udTzNXlGn95hq5XcYh/3BFbh8+oIcWjBncNIxmxjEAtMR7C4BEoEQCqdy5W0tLvCquqJa31tdsxw5D+xdFLhyYo/FDc9ucLWrGMQC0xHsLSG0ESiSken9AW2vr1RgIKc3jUr/szHbvsGHGMQC0xHsLSD0ESgAAAMSEWd4AAACICYESAAAAMSFQAgAAICYESgAAAMSEQAkAAICYECgBAAAQEwIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJgQKAEAABATAiUAAABiQqAEAABATAiUAAAAiAmBEgAAADEhUAIAACAmBEoAAADEhEAJAACAmBAoAQAAEBMCJQAAAGJCoAQAAEBMCJQAAACICYESAAAAMSFQAgAAICYESgAAAMSEQAkAAICYECgBAAAQEwIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJgQKAEAABATAiUAAABi8v8BRZ0v/RMgHKoAAAAASUVORK5CYII="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# get node dataset from data service\n",
     "centerville_epn_link = '5b1fdc2db1cf3e336d7cecc9'\n",
@@ -128,14 +165,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "start_time": "2023-10-23T14:57:26.735406Z",
      "end_time": "2023-10-23T14:57:26.887482Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset already exists locally. Reading from local cached zip.\n",
+      "Unzipped folder found in the local cache. Reading from it...\n",
+      "Dataset already exists locally. Reading from local cached zip.\n",
+      "Unzipped folder found in the local cache. Reading from it...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/lz/cytsgpz97f34yd69304b9vyc0000gr/T/ipykernel_12874/3196477836.py:18: FionaDeprecationWarning: This function will be removed in version 2.0. Please use CRS.from_epsg() instead.\n",
+      "  NetworkUtil.build_link_by_node(node_filename, graph_filename, id_field, out_filename)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": "True"
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# this process can be done using the local shapefile, \n",
     "# instead of using the dataset from the incore data service.\n",
@@ -166,14 +230,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "start_time": "2023-10-23T14:57:30.115378Z",
      "end_time": "2023-10-23T14:57:30.191292Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset already exists locally. Reading from local cached zip.\n",
+      "Unzipped folder found in the local cache. Reading from it...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/lz/cytsgpz97f34yd69304b9vyc0000gr/T/ipykernel_12874/1565815967.py:20: FionaDeprecationWarning: This function will be removed in version 2.0. Please use CRS.from_epsg() instead.\n",
+      "  NetworkUtil.build_node_by_link(link_filename, link_id_field, fromnode_field, tonode_field, out_node_filename, out_graph_filename)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": "True"
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# this process can be done using the local shapefile, \n",
     "# instead of using the dataset from the incore data service.\n",
@@ -219,14 +308,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
      "start_time": "2023-10-23T14:57:33.444367Z",
      "end_time": "2023-10-23T14:57:34.943261Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "network dataset is created with id 6536d02dfaa0854c4fb04416\n",
+      "attching files to created dataset\n"
+     ]
+    }
+   ],
    "source": [
     "dataset_prop = {\n",
     "  \"title\": \"Test epn network\",\n",

--- a/manual_jb/content/notebooks/create_network_dataset/create_network_dataset.ipynb
+++ b/manual_jb/content/notebooks/create_network_dataset/create_network_dataset.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "start_time": "2023-10-23T14:56:54.196461Z",
@@ -35,22 +35,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "start_time": "2023-10-23T14:56:56.525730Z",
      "end_time": "2023-10-23T14:57:06.236064Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Connection successful to IN-CORE services. pyIncore version detected: 1.12.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "client = IncoreClient()\n",
     "datasvc = DataService(client)"
@@ -65,24 +57,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "start_time": "2023-10-23T14:57:10.022062Z",
      "end_time": "2023-10-23T14:57:10.181272Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dataset already exists locally. Reading from local cached zip.\n",
-      "Unzipped folder found in the local cache. Reading from it...\n",
-      "network_graph.csv successfully created.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# get link dataset from data service\n",
     "centerville_epn_link = '5b1fdc2db1cf3e336d7cecc9'\n",
@@ -113,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "scrolled": true,
     "ExecuteTime": {
@@ -121,26 +103,7 @@
      "end_time": "2023-10-23T14:57:15.782454Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dataset already exists locally. Reading from local cached zip.\n",
-      "Unzipped folder found in the local cache. Reading from it...\n",
-      "{0: (-97.4745, 35.266), 1: (-97.4745, 35.2626), 2: (-97.4873, 35.2626), 3: (-97.4873, 35.196), 4: (-97.4836, 35.196), 5: (-97.4369, 35.196), 6: (-97.4838, 35.2509), 7: (-97.5113, 35.2509), 8: (-97.5023, 35.246), 9: (-97.4903, 35.2567), 10: (-97.4964, 35.2604), 11: (-97.49950726683866, 35.2427), 12: (-97.4691, 35.2427), 13: (-97.47226381921406, 35.246689303630674), 14: (-97.48874482954297, 35.23152065345497), 15: (-97.4888, 35.2165), 16: (-97.4768, 35.2165), 17: (-97.4888, 35.2101), 18: (-97.4601, 35.2509), 19: (-97.46507448011698, 35.25914896023397), 20: (-97.4442, 35.259), 21: (-97.4466, 35.2406), 22: (-97.4466, 35.2305), 23: (-97.4691, 35.2312), 24: (-97.3976, 35.2045), 25: (-97.3964, 35.2311), 26: (-97.40211901205474, 35.23360380241095), 27: (-97.4021, 35.2561), 28: (-97.4112, 35.2398), 29: (-97.41233569457059, 35.21449438614856), 30: (-97.43521617501703, 35.215086558444916), 31: (-97.4656664519788, 35.21571961356189)}\n",
-      "DiGraph with 32 nodes and 30 edges\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": "<Figure size 640x480 with 1 Axes>",
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAApQAAAHzCAYAAACe1o1DAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAABfEklEQVR4nO3de3hU1d328XvPDAkkIJpAUJSASOCpKT5qG6EoYiqgVRuL+igtoCIqWqiKRUVsOSm04gGt1iMeKmLxBBaLVURToIJpak95o5JQJIOCpEkUIRMmzOH9AycSksAks/fsPTPfz3X1qmQme689p9yz1m+tZYTD4bAAAACADnLZ3QAAAAAkNgIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJgQKAEAABATAiUAAABiQqAEAABATAiUAAAAiAmBEgAAADEhUAIAACAmBEoAAADEhEAJAACAmBAoAQAAEBMCJQAAAGJCoAQAAEBMCJQAAACICYESAAAAMSFQAgAAICYESgAAAMSEQAkAAICYECgBAAAQEwIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJgQKAEAABATAiUAAABiQqAEAABATAiUAAAAiAmBEgAAADEhUAIAACAmBEoAAADEhEAJAACAmBAoAQAAEBMCJQAAAGJCoAQAAEBMCJQAAACICYESAAAAMSFQAgAAICYESgAAAMSEQAkAAICYECgBAAAQEwIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJh47G4AgEOr9we0tbZejYGQ0jwu9cvOVGY6b10AgHPwVwlwoMqdu7W0xKviTdXy1vkUPuA2Q1JuVoYKB+Vo3JBc5fXqZlczAQCQJBnhcDh8+LsBiIdtdT7NXFGm9Ztr5HYZCobafntGbh8+oIcWjBmsPlkZcWwpAADfIFACDrGs1KvZK8sVCIUPGSQP5nYZ8rgMzS3K19iCXAtbCABA6wiUgAM8XFype1dXxHyc6aMHamphngktAgAgeszyBmy2rNRrSpiUpHtXV+jFUq8pxwIAIFoESsBG2+p8mr2y3NRjzlpZrm11PlOPCQDAoRAoARvNXFGmQDvqJaMRCIU1c0WZqccEAOBQCJSATSp37tb6zTXtmoATjWAorPWba7S5erepxwUAoC0ESsAmS0u8crsMS47tdhl6/n1qKQEA8UGgBGxSvKna9N7JiGAorOKKakuODQDAwQiUgA32+APyWjxxxlvrU70/YOk5AACQCJSALapq62X1ArBhSVtr6y0+CwAABErAFo2BUFKdBwCQ2giUgA3SPPF568XrPACA1MZfG8AG/bIzZc387m8YX58HAACrESgBG2Sme5SblWHpOXKzM5SZ7rH0HAAASARKwDaFg3IsXYeycGCOJccGAOBgBEokpHp/QOXbd+kf3i9Uvn1XQi6PM25IrqXrUI4fmmvJsQEAOBjjYUgYlTt3a2mJV8WbquWt8zVbdseQlJuVocJBORo3JFd5vbrZ1cyo5fXqpuEDemjDllpTg6XbZWhY/2wNyHH+YwAASA5GOBy2ejk8ICbb6nyauaJM6zfXyO0yDhm+IrcPH9BDC8YMVh+L6xRjta3Op5GL1spv4vI+6R6X1kwb4fhrBwAkD4a84WjLSr0auWitNmyplaTD9uRFbt+wpVYjF63VslJn72fdJytDc4vyTT3mvKJ8wiQAIK4IlHCsh4srNWN5mfyBULuHhIOhsPyBkGYsL9PDxZUWtdAcYwtydcaAbFOOdcaAHrqsgNpJAEB8ESjhSMtKvbp3dYUpx7p3dYVedHBP5bJSr/6yudaUY/1lc42jrxUAkJwIlHCcbXU+zV5ZbuoxZ60s17Y6n6nHNEMqXSsAIHkRKOE4M1eUKWDycjqBUFgzV5SZekwzpNK1AgCSF4ESjlK5c7fWb64xfX3GYCis9ZtrtLl6t6nHjUUqXSsAILkRKOEoS0u8lu4e8/z7LesLw+Gw1qxZo7ffftuS87bFjmsFAMAKBEo4SvGmakt3jymuqG76dzgc1ttvv62hQ4dq1KhRuu666yw5b1viea0AAFiJQAnH2OMPyGvxZBJvrU979u5rCpKjR4/WBx98IEkKBoOWnvtA8brWRNySEgCQeNh6Ec3U+wPaWluvxkBIaR6X+mVnKjM9Pi+Tqtp6Wb1tU1hS3qnD9PlHf2v6WSRI7ty5U2effbbFLdjPn9FT4W9PsPQcYUlba+uV37u7pecBAIBACcfskd1o4vaDh9Kt+1H6XJJhGDpw51GXy6WcnJy4tGF3WrY+jcN54vWYAgBSG4EyhUWzR3ZYUlWdT0tKqvTsxq2W7pGd5olPBcaKV19W484tmjNnjlauXCmPx6NAIKCePXvq97//fVzaUL59l85/6C+WnydejykAILXx1yZFOXGP7H7ZmbJmzvM3jK/Pc8opp+gPf/iD/v73v+u8886TJKWnp1t89m/E81oBALAaPZQp6OHiyg5vaxgMhRUMhTVjeZlq9vg1tTDPtHZlpnuUm5WhKgsnq+RmZzSrCY0Ey3/9619qbGy07LwHs+NaAQCwCj2UKcbpe2QXDsqxdG3GwoGt10j+7//+rwoKCiw5b1vsulYAAMxGoEwhibBv9LghuZauzTh+aK4lx+6IZLzWen9A5dt36R/eL1S+fRfLFgFAimA8LIVYuW/0kklDTDleXq9uGj6ghzZsqTU1bLldhob1z9aAHOtmqbdXslyrU1YJgL3LfgFIbUb4wHVTkLQqd+7WqAfWWXb8NdPONC3AbKvzaeSitfKbuORNuselNdNGWDI7PRaJfK3RrBIQEbndylUCUhWBHoATMOSdIhJp3+g+WRmaW5Rv2vEkaV5RviNDTKJeqxNXCUg12+p8mvBUiUY9sE5LSqpUdVCYlJov+zXqgXWa8FSJqSUqABBBoEwRibZv9NiCXE0fPdCUY90yepAuK3BO7eTBEu1aHy6u1IzlZfIHQu1+TQVDYfkDIc1YXqaHiystamHyI9ADcBoCZQpI1H2jpxbm6dcXDVa6x9Xu3lW3y1C6x6W7LxqsKYUDTG2XFRLlWp2+SkAqINADcCICZQqI1x7ZW2vrTT/u2IJcrZk2QsP6Z0vSYcNW5PZh/bO1ZtoIR/dMHszp15oIqwQkOwI9AKdiUk4K+If3C415dIPl51lx/TCdknuUZcdvmnxQUS1vbSuTD7IzVDgwR+OH5jpqNndHOPFaJzxVYtmMdLNWCUhmiTyBC0DyI1CmgHjtG73qZ2cov3d3y88j7V8e5ZKJ16uhMaDf/uaBpF4exQlLwSTSKgHJikAPwMkY8k4BybhvdGa6Rxn+OmX4diq/d/ekDZPS/mvN791dp+QeZdu1JtIqAcmocudurd9cY/rEumAorPWba7S5erepxwWQegiUKSCyb7SV2Dc6uSXaKgGJxufzac2aNQoEWp/YRqAH4HQEyhTBvtHoqERdJSCRvPrqqxo1apQGDRqkF154QcFgsNntBHoATkegTBHJuG804iNeqwT85V+b9Mknn6iqqkrbtm3TZ599ps8//1zV1dWqqalRXV2dvvzyS3311Vfas2ePfD6f/H6/9u3bp2AwqEQuB29oaJAkffLJJxo3bpxOPPFEvfzyywqFQgR6AAmBMcoUYeW+0QW5R+iEnl1NOyacpdHEWcWHUvSji9S4I/YlcVwul1wul9xud9N/t/a/Q90ey+925BgVFfuvOxKKKyoqdOmllyorK0u/emxJ3Jb9itekOgDJh0CZQhaMGayRi9aaGijDwYBeve0SZdy0S/n5+crPz9egQYM0aNAgFRQUKDf30D2XTpjBjENL88RnIOOJRx/RcV2lUCjU7H/BYLDFzzpyHzOO1dZth/qdQCBw2ONt37691cekrq5O5R9tkmTOTkqHEq8vDgCSE3+5U0hk3+gZy8tMO+aNpx+jm+/5r/aGQvrggw/0z3/+U5IUDAZ15JFH6osvvmjxO01rLG6qlreulTUWszJUOChH44bkKq8XS8nYLbJKgJW9ZIakS84dkbJfJh566CHdeOONCofDcrvdcrvduu6663TrrbfqS6Or/hCHZb/i9cUBQHJKzU/vFDa2IFc1e/ym7LZxy+hBmlI4QJ/efLPuu+8+hcPhpskEhmFoypQpze6/rc6nmSvKtH5zjdwuo9We0rCkqjqflpRU6dmNWzV8QA8tGDOYhZdtFFkloMrCOr5UXyUgHA4rHA6rc+fOmjJliqZPn66jjz5aknSkPxCXQB/PZb8AJB++kqYgs/eNvv3229W1a/Mayp49e2rGjBlN/15W6tXIRWu1YUutJB122D1y+4YttRq5aK2WsUWcrVglwFoXXXSRFi1aJK/Xq3vvvbcpTEos+wW0V70/oPLtu/QP7xcq376LCWdxwidIihpbkKvTT+hx2B7DiMjtw/pnt+gxzMrK0syZMzVz5kyFw2F5PB7V1dXpjDPO0NKlS1VcndbhHtFgKKxgKKwZy8tUs8evqYV5HToOYjNuSK6e3bjVkmOzSoB03HHH6aabbmrz9sJBOVpSUmXJSg0EeiQDSqnsx9aLMGXfaJ/Pp+OPP17V1dV64oknVFBQoHHjxqnuqP9R+vCrTGvr3RcN1mUF+8PHxRdfrIaGBr3xxhumHR9tY+s/+7D1JdC6aEqpIiK3U0plDQIlmoll1vWbb76pdevWaf78+TIMQ5Xb63T+IxvVGDz870Yr3ePSmmkj1Ccrg0AZZ9vqfBq5aK38Js4GPvD5xKER6IHmlpV6NXtluQJfj2RFy+0y5HEZmluUr7EFqT06YiZqKNFMLPtGn3vuuVqwYIEMY3+t3bw/VSoYNrfuLhAKa+YK82apI3qRVQLMNK8onzAZpQVjBstjch2rx2VowZjBph4TiIeHiys1Y3mZ/IFQu79kBUNh+QMhzVhepoeLKy1qYeohUMISlTt3a/3mGtNrvoKhsNZvrtHm6t2mHhfRGVuQq+mjzVkT8ZbRg5rKF3B4BHpgv2WlXlNWKpGke1dX6EUmfZqCQAlLLC3xWjor+Pn3+QCwi9mrBCB6BHqkum11Ps1eWW7qMWetLNc2i7c3TQUESliieFO1pXuHF1dUW3JsRGdsQa7WTBuhYf2zJemwwTJy+ynHZOjtm84kyMSAQI9UNnNFmQIm/22hlMocLBsE0+3xB+S1+Nuet9anowxevnbqk5WhJZOGRL1KwDkDMjQsv7+qfvddvfXWW8rKyrKr6QnPzGW/gEQRKaUy24GlVKx20HHM8obpyrfv0vlx2CruW1WvyfjyM2Z5O8ihVgn49NNP1adPH0lSr1699PLLL2v48OF2NjcpmLHsF5AI5qwst3Q91glD+mqOyXXKqYQuHpiu0cRlZQ4lbLhlTZUmOiqySkBrPJ5vPm6qq6s1YsQIzZ49W3fccUez29A+eb26aU5RvuYoP6ZlvwCni0cp1RwRKDuKGkqYLs0Tn5eVETZxgUtYzu12N/13ZO/quXPnasSIEfL5KIg3QyzLfgFOFq9SKrZp7DgCJUzXLzvT8p5DQ1J641cWnwVmaq0X0jAM/b//9/9UU2N+XRSA5FFVWy+r6/PCkrbW1lt8luRFoITpMtM9yrW46D83O0PuMN8kE8mBgTKy+P0tt9yiqqoq5eYy6xtA2+JVShWv8yQjAiUsUTgox9J1KAsH5lhybFinU6dOcrlcSktL01VXXSWPx6OsrCwdeeSRdjcNgMPFq5QqXudJRjxysMS4IbmWFk+PH0qPVqLp3Lmz1qxZo08++USLFy/WNddco7vvvlu7du2yu2kAHC5epVT9sjMtPkvyIlDCEnm9umn4gB6m91K6XYaGD+jB8icJqrCwUL1795Yk3XHHHfL5fFq0aJHNrQLgdPEqpWIiW8cRKGGZBWMGy2NyoPS4DC0YM9jUY8Iexx57rH7605/q/vvvV21trd3NAeBwlFI5G4ESljm6Wyed23O3qcecV5TPLh9J5LbbblMoFNLChQvtbgoAh6OUytkIlDBVOBzWxo0bNWXKFB111FH6zY2XKa/hY1OOfcvoQewBnWRycnJ000036aGHHtKOHTvsbg4AB6OUytkIlDDFp59+ql/84hfq27evhg0bpscee0z19fvX83rw2h/o1xcNVrrH1e4PArfLULrHpbsvGqwphQOsaDpsNn36dKWnp+tXv/qV3U0B4HCUUjkXgRKmmDlzpubPn69t27ZJkkKh/Wt5nXDCCTrxxBM1tiBXa6aN0LD+2ZJ02GAZuX1Y/2ytmTaCnskkduSRR2r69Ol6/PHH5fV67W4OAAfrk5WhuSbvt00plTkIlDDFggUL1L9/f7lc37ykPB6P/u///q/p332yMrRk0hC9fdOZmjCkr/pmZ7RYBsKQ1Dc7QxOG9NWaaWdqyaQhvNFTwI033qgjjjhCd955p91NAeBwYwtyNX30QFOORSmVeYxwOGz1bkZIEa+//rouvPBCHfiSev/99zVkyJA2f6feH9DW2no1BkJK87jULzsz6mUbLr74YjU0NOiNN96Iue2w3/33369bb71VH330kfLy8uxuDgCHW1bq1eyV5QqEwu2arON2GfK4DM0ryidMmohACVP87W9/09lnn638/Hzt2rVLH374oXr27KnPP/+8Wa+lmQiUyaWhoUEDBgzQWWedpaVLl9rdHAAJYFudTzNXlGn95hq5XcYhg2Xk9uEDemjBmMGMfpmMFTwRs3//+98aPXq0TjzxRL311lsKBAK65JJLNGLECMvCJJJPly5d9Mtf/lI//elPdfvtt+vb3/623U0C4HCRUqrKnbu1tMSr4opqeWt9OjBWGtq/aHnhwByNH5rLbG6L0EOJmHz88cc688wzddxxx+ndd9+N677M9FAmn8bGRg0aNEinnHKKli9fbndzACSgen9Aw865UB9XbNbbb/1J3xmYyw44cUD3ETrsP//5j84++2z16tVLq1evjmuYRHJKS0vTnDlztGLFCn3wwQd2NwdAAvqsaov+vfYNNe6o0IqnHyJMxknK91DGMikklXm9Xg0fPlydO3fW2rVrdfTRR8e9DbH0UPK8O1cgENC3v/1tHX/88frTn/7U9HOeMwDRmDBhgl544QWFQiGlpaWpqqrKlr9RqSYlP42bai02Vctb10qtRVaGCgflaNyQXOX1otbiYNu3b9f3v/99ud1uvfPOOwnzRuV5Twwej0fz5s3TZZddphXvvq9/7enGcwYgKhUVFVq6dGnTaiPBYFALFy7U/fffb3PLkl9K9VAyGyx21dXVGjFihPbs2aP169erX79+trUl2h5KnvfEU1WzRz++f6W2h7vznAGI2oQJE7Rs2TIFAoGmn6Wnp2vr1q0J0/mRqFKmhnJZqVcjF63Vhi21knTYNasit2/YUquRi9ZqWSk7eNTV1WnUqFH68ssv9e6779oaJqPF8554lpV6NfrB9dppHCmJ5wxAdD777DO98MILCgaDTSuMuN1u+f1+/fa3v7W5dckvJYa8Hy6u1L2rKzr0u8GvF0ydsbxMNXv8mlqYmgsu79q1S+ecc462b9+uP//5zwmx8DTPe+LhOQPQUd26ddPUqVO1e/du/fOf/9THH3+ssWPHKhwOa8SIEXY3L+kl/ZD3slKvZiwvM+14d180OOVW1t+zZ4/OOeccffjhh3r33Xd1yimn2N0kSYce8uZ5Tzw8ZwDMcuedd+qRRx7Rjh077G5KykjqIe9tdT7NXllu6jFnrSzXtjqfqcd0soaGBhUVFamsrExvvvmmY8LkofC8Jx6eMwBIbEkdKGeuKFOgHft7RiMQCmvmCvN6UZzM7/froosuUklJiVatWnXIPbmdhOc98fCcAUBiS9pAWblzt9ZvrmnXhvHRCIbCWr+5Rpurd5t6XKfZt2+fxo4dq+LiYv3hD3/Q8OHD7W5SVHjeEw/PGQCzJXk1nyMlbaBcWuKV22VYcmy3y9Dz7zefSRoOh/Xaa6/p/PPPV3m5uUN38RYMBnX55Zdr1apVevXVVzVy5Ei7mxS1eD/vOLyXXnpJY8eObXPnG54zAFYwDGs+V9C6pA2UxZuqTe/xiAiGwiquqJb0TZA86aSTNGbMGL3xxhv629/+Zsl54yEUCunqq6/Wyy+/rGXLlun888+3u0ntEq/nHdF7++239eKLL+q73/2uLrjgghbBkucMABJfUi4btMcfkNfiYnxvrU/PvfCi7p4/Tx9++GHTmlfS/tpDny/xJgOEw2FNmzZNv/vd7/TUU0/p3HPPdfR1BAIBBYPBpjbWx+l5/++XXykzLSnfOpYIBALyeDwKBAJ68803tWrVKp177rmaNWuWBp9aEJfnrN4fYJtGALBQUi4bVL59l85/6C+Wn2f70z/TvupPLD8PotMp53j1vuohy8/D826eRc+8rAc2dbH8PKt+dobye3e3/DwAnGHevHl67LHHtH37drubkjKS8it7YyAUl/Oc+t3T9Nc/bZVhGAqFvjnnddddpzPPPDMubTDLSy+9pNdee01XXnmlRo8ebXdzorJo0SI1NjbqtttukyR5fW49utn689654NfKzQhaf6Ik8eSTT2rt2rVN7xHDMJSWlqYLL7xQQ08/Q9rUem2lmeL1mQAAqSopA2WaJz6loU89+bjSfXfprrvu0pIlS2QYhoLBoIYOHaof//jHcWmDGebPn6/XXntN99xzj6ZPn253c6L2yiuvqKGhoemxLt++S4/GoWf6gh+cQ29XO7z77rv685//LJfLpS5duujnP/+5brrpJh111FEq374rLm2I12cCAGdIwsFXx0vKT9l+2Zmyem6X8fV5BgwYoGeffVabNm3S+PHj5Xa7lZOTY/HZzXP//ffrF7/4hebNm5dQYbI18XzeEb2cnBxlZmbqF7/4hbZt26a5c+fqqKOOksRzBsA6zPKOr6QMlJnpHuVmZVh6jtzsjGZF/pFguWfPHp177rmWntssjzzyiH7+85/r9ttv1y9+8Qu7mxMzO553HN68efNUW1vbLEhG8JwBQHJIykApSYWDcixd265wYOu9kJ07d06Ib0XPPPOMpkyZohtvvFHz589PiDZHw67nHW1zu91KS0tr83aeMwBIfEkbKMcNybV0bbvxQ3MtOXY8/P73v9ekSZM0efJkLVq0KGnCpMTznoh4zgAg8SVtoMzr1U3DB/QwvecjHAyox77/qmd6Ys4aXbFihSZMmKAJEybokUceSaowKVn3vLtdhoYP6KEBOd1MPS54zgCYj0k58Ze0gVKSFowZLI+Jf6TC4bDchlT5wjx961vf0vLly007djy88cYbuuyyy3TxxRfrqaeearYYezIx+3mXJI/L0IIxg009Jr5hyXtVYZ4zIIUlW4eJ0yVnovhan6wMzS3KN+14hmHov2/+Vv933vd16qmn6uKLL9aYMWP06aefmnYOq7zzzju66KKLdN555+n555+Xx5O8kxTMft4laV5RvvpYPHkklVnxXq19+zGV/3WdaccEALQtqQOlJI0tyNX00QNNOdaXa5/Tj07qpWeffVZ79+7V008/rffff18nnniifvvb3yoYdOZi13/5y19UVFSks846Sy+++KI6depkd5MsZ+bzfsvoQbqswPl1ePX+gMq379I/vF+ofPsu1fsDdjepXcx8zm4sPF6nH23oggsu0LPPPmvKMQEAbUvebqoDTC3MU4+u6Zq9slyBULhdEwDcLkMel6E5PzxRxbXdtXjxYt16661avHixtmzZoldeeUVLlizR1KlT9fzzz+uJJ57Q4MHOGWb761//qvPOO0+nnXaali9frvT0dLubFDdmPO/zivIdHSYrd+7W0hKvijdVy1vn04FXaEjKzcpQ4aAcjRuSq7xezq8lNPM5+9n3l2vKlCmaOHGitm3bpl/84hcMgQGARZK+hzJibEGu1kwboWH9syXpsBMAIrcP65+tNdNG6Men9dVjjz2mq6++WgsXLtTtt9+uI444Quecc45GjRqldevW6csvv9Spp56qO+64Qw0NDZZf0+H885//1DnnnKNvf/vbev3115WRkXpDtrE+704Nk9vqfJrwVIlGPbBOS0qqVHVQmJSksKSqOp+WlFRp1APrNOGpEm2r89nR3HYx6znzeDx67LHHdOedd2rWrFmaPHmyAoHE6rUF0DFMyok/I5yCj3pTr05Ftby1rfTqZGeocGCOxg/NbTFDNBQK6brrrtPixYv12GOP6Z133tFLL72kX/7yl7r99tu1cOFCzZ8/X/369dPjjz+uwsLCpt/1+XwqLy9XQUGB5df44YcfasSIEerbt6/eeecdde+efFsFXnzxxWpoaNAbb7wR1f1jed6dZFmpN6YevLlF+Rrr0KB8MLOes2eeeUbXXHONfvCDH2jZsmXKzGTnHCCZzZ49W08//bS2bdtmd1NSRkoGygPV+wPaWluvxkBIaR6X+mVnHnZXjQND5dNPP60dO3bojjvu0A9/+EMtWbJEn332ma699lr95S9/0cSJE3XPPfcoOztbP/7xj7Vs2TJt3LhRQ4cOtayNlZWVOvPMM9WzZ08VFxcrOzs76nMlkvYGygPV+wM68bQR+vy/NfrTqtc15MT+CbGbysPFlbp3dUXMx5k+eqCmFuaZ0KL46ch79UBvvvmmLrnkkqYe+549e1rYWgB2IlDGn/P/glosM92j/N7t671zuVx67LHHJElXXXWVnnnmGb3++uv6yU9+oqFDh+q1117T2rVrm+ot//jHP+qqq67SsmXLZBiGJk+erL///e9yu91tnqOjtXFbt27V2WefrSOPPFJr1qxJ2jAZq3+Uvi/vvzdIkl5+YpG+/+ijNrfo8JaVek0Jk5J07+oK9eya7tgh/dZ05L16oHPPPVdr167Veeedp2HDhunNN9/UCSecYGILASB1pUwNpdkiofLqq6/WxIkTVVNTo7/+9a8KhUI67bTTtHr1al177bX66KOPdPrpp+vuu++WtL+u49///rcef/zxVo8bS23cZ599prPPPludOnXSmjVrlJPDlnNtmTVrVtMEjcWLF8vr9drcokPbVufT7JXlph5z1sryhKipNNN3vvMdbdy4UYZh6Hvf+55KS0vtbhIAJAUCZQwODpXvv/++SkpKdMYZZ+i8887TwoULdfTRR6t///4tZpfedtttqq6ubvazZaVejVy0Vhu21ErSYevjIrdv2FKrkYv+rBFXzdS+ffv07rvv6thjjzXxSpPLhg0bVFxc3FS0HQ6HNX/+fJtbdWgzV5QpYPL2hIFQWDNXlJl6zETQv39/bdiwQSeccILOOuusDpVMAHC2FK/mswWBMkYHh8rXXntNf/jDH3T77bfrtttu0w9/+EPdf//9LV7ce/bs0dVXX93074eLKzVjeZn8gVC79zUOhsLyB8IKnHqpJt3/svr27WvKtSWrWbNmNSs3CAaDevrpp1VVVWVjq9pWuXO31m+uMX2/62AorPWba7S5erepx00EPXr00DvvvKORI0eqqKhITz/9tN1NAmAylgmLLwKlCQ4Olc8//7zmz5+vl156Se+++666deumfv36qWvXrs1+7/XXX9d//vMfU2vjnvmgRi+WOnv41k4VFRV65513FA6Hm7aedLvdCgQCTXWxTrO0xGv6PtcRbpeh599PzddLRkaGXn31VV1zzTWaNGmS5s6dS68GAHRQyk/KMcuBE3UmTpwoSbriiis0cOBA/ehHP9KePXv0xz/+UQUFBdqxY4e8Xq8+/vhjdTryaM1+1tzt4WatLNewE3qwVWArjjvuON13332qr6/Xu+++q7///e+67bbbZBiGioqK7G5eq4o3VZveOxkRDIVVXFGtOTJ3q8pE4fF49Mgjj6hPnz6644479Omnn+rRRx9N6q1JAcAKfGqaqK1QWVpaqksvvVQjR47Ugw8+qOuvv14nnHCCCgsLNeGpEstq45ZMGmLqcZNBRkaGbr75ZklSIBBQZWWlZs6caXOr2rbHH5DX4okz3lqf6v2BhFg2yQqGYWjmzJk69thjdfXVV2vHjh168cUXWasSANqBIW+THTz8/bvf/U49evTQW2+9pZ/+9KeaMmWKrr32Wvn9fmrjbGYYhuOHOKtq61vM8jdbWNLW2nqLz+J8V1xxhVatWqW1a9eqsLCwxaQ5AInD6Z/tyYhAaYHWQmWnTp304IMP6umnn9Zzzz2n73//+3qi+CNq42yUCAXbjYFQUp3H6UaPHq21a9fK6/Vq2LBh2rx5s91NAtBBifAZn0wIlBaJhMpJkyY1hUpp/1D42rVr9cknn+il9eWW18bh0Jz+LTbNE5+3aLzOkwhOPfVUbdy4UW63W8OGDdNf//pXu5sEAI7HXxELuVwuPf744y1C5dChQ7V2Q4mMbtZu/RapjUPrEmHIu192pqz+jm18fR584/jjj9d7772nAQMGqLCwUKtWrbK7SQDgaARKi7UVKhvTjpAs7o6nNu7QEiFQZqZ7lGvxbP3c7IyUnZBzKJG1KkePHq0LL7xQixcvtrtJAOBY/BWJg0iolL6Z/X1SYXyWqKE2rm2JECglqXBQjpaUVFlSHuF2GSocyBadbenSpYteeeUV3XDDDbrmmmv06aefavbs2dRmAcBBCJRxcnCoXPDoc5KOsvy81Ma1LVFCwbghuXp241ZLjh0MhTV+aK4lx04WbrdbDz/8sI477jjNnDlT27Zt02OPPaZOnTrZ3TQAbUiEzoJkQ6CMowND5R03XKs+N78kWVghR23c4SXCh05er24aPqCHNmypNbWX0u0yNKx/tgbkdDPtmMnKMAzdfvvtOvbYYzVp0iTt2LFDL730UovdrwA4R6J0GiQLuq/iLBIqr7p8nPZ98bml56I27tASZchbkhaMGSyPyUtMeVyGFowZbOoxk93ll1+uVatWaf369axVCQAHIFDaIBIq+3f2KRwKWnIOauMOL5ECZZ+sDM0tMnd7xHlF+WzP2QGjR4/WunXr9Omnn+p73/ueKisr7W4SANiOQGkTl8ulxTOukOFyW3L8YCisof2z9A/vFyrfvovlg1qRaMMhYwtyNX30QFOOdcvoQbqs4JvayXp/QOXbd/F6idIpp5yijRs3qlOnTho2bJhKSkrsbhIA2IrxUBsNOrq7zhiQrfcq/6uwYX62v27p35v+25CUm5WhwkE5GjckV3m9qJtLpB7KiKmFeerRNV2zV5YrEAq3q6bS7TIUDgZ09clHaErhAFXu3K2lJV4Vb6qWt87XbItHXi+H169fP7333nsqKipSYWGhXnrpJV1wwQV2NwuAEqM+PtnQQ2mzX405SWmdPJLFL/6wpKo6n5aUVGnUA+s04akSbavzWXrORJCIHzpjC3K1ZtoIDeufLUmH3b4zcvuw/tna9ti1mn3dWA2f9aJGPbBOS0qqVHVQmJR4vUQrOztba9as0bnnnqsLL7xQTzzxhN1NAvC1RBuFSnQESps11cbF6YUf6dHasKVWIxet1bLS1N3vOxF7KCP6ZGVoyaQhevumMzVhSF/1zc5osV6AIalvdoYmDOmrNdPO1JJJQ3TqD36sY65+RN69nSXpsD2cvF4Or0uXLnr55Zd1/fXXa/LkyZo1a1bCvq4AoKMY8naAsQW5qtnj172rK/b3VMYhXAa/Hi6dsbxMNXv8mlqYZ/k5nSaRA2VEXq9umlOUrznKV70/oK219WoMhJTmcalfdmazWf4PF1dqZ7+RMsLhdn9z5/VyaG63Ww899JD69OmjGTNm6NNPP9Xjjz/OWpUAUgaB0iEOrI1r3BewpKayLfeurlDPrunNJmmkgmQbDslM9yi/d/dWb1tW6t3/hUWxX3eqvl4OxzAM3XbbbTr22GM1ceJE7dixQy+//DJrVQJICQx5O0ikNu70vJ6SZNmSQq2ZtbI85WrkkqGHMhrb6nyavbLc1GOm4uslWuPHj9cbb7yh9957T2eddZZ27txpd5OAlJMKn+1OQ6B0mD5ZGXp+0lC9deMZyt27VfvqtkstpkyYLxAKa+aKMsvP4zSp8KEzc0WZAibvA56qr5dojRo1SuvWrdP27dv1ve99TxUVFXY3CUg5yTYK5XQESocadHR3rV00VT8Ilmjb/Zfq+uO/1Irrh+nRcadacr5gKKz1m2u0uXq3Jcd3olTooazcuVvrN9eYumWjlJqvl/Y6+eSTtXHjRqWnp2vYsGF6//33m257+umntX79ehtbBwDmIlA6mMvl0hNPPKGJE36i26+boLI/v66SLXWHXSamo9wuQ8+/nzqzeBM9UIZCIZ177rm69dZb9d///rfV+ywt8fJ6sVHfvn313nvv6X/+53/0/e9/XytXrtQjjzyiSZMm6Zprrkno1x8AHIhA6XCRUHnVVVfpyiuv1Mq//cf03qaIYCis4orU2Zs40YdD/H6/3nrrLd1zzz3Kzc1tNVgWb6rm9WKzrKwsvf322/rBD36gH/3oR5oyZYokadOmTdqwYYPNrQMAczDLOwFEQmXA8Ki40WXpqkLeWp/+U/WpMtKs2RLSTA0NDdq7d6927NjRod//6quvFAqFOvz7dmtoaGj677179+q+++7Tb37zG1111VWaMWOGsnr1ltfiiTPeWp/q/YFmyxOhpS5duuimm27Sa6+91tQr6fF49Nhjj+n0008/5O8ebjkoAHACI8yYS8L4f59+qQt++57l59n+9M+0r/oTy88D6xxxxBHa8JFX5z/0F8vPtepnZ7S5XBH227Jli0499VTt3r1boVCo6eedOnXS559/rqysrGb3Z1tMIDa33367XnzxRW3ZssXupqQMvuYmkH0WDV0e7P4HH9LxCfA3av78+WpsbNTcuXM79PsrV67UM888oxUrVpjcsvjw+/26+OKLm/7tcrkUCoV00kknae7cuWoMhA7x2+aJ13kS2ZYtW+Tz+RQKheTxeBQIBCRJ+/bt05NPPqnbbrtN0v4lnmauKNP6zTVyu4xWyxUO3Bbz2Y1bNXxADy0YM1h9sjLieUmA4yV6WVOiIVAmkDRPfEpeC89MjB6np59+Wg0NDTr//PM79PtbtmyRy+Xq8O/bLTLkHZlcNGLECM2bN09nnHGGJKl8+664tCNer8tENnLkSH3xxRdav3693n77bf3pT3/SRx99JEn61a9+pdtuu03LSr2avbK8aYmn9m6LObcoX2NZbB6ATQiUCaRfdqYMWbsqpfH1eVJBon977dSpk3JycpSfn98sSEbwenGWzMxMnXvuuTr33HN133336fPPP9dzzz2n3bt36+HiyqadjNqLbTERL9Tz4lB4JSSQzHSPcrMyVGXhRIvc7IyU+YBI9GWDPB7PIXdh4fXibEcffbRuvfVWLSv1asZycxaJZ1tMmI16XkSLsaoEUzgox9J1BQsH5lhybCdK9EAZDV4vzsa2mHCqbXU+TXiqRKMeWKclJVWqOihMSs3reUc9sE4TnipxzGsv2T/bnYhAmWDGDcm1dF3B8UNTq2cj2T90eL04G9tiwomWlXo1ctFabdhSK6n99bzLSp2x4UGilzUlGgJlgsnr1U3DB/QwvdfJ7TI0fEAPDchJnSGLVOih5PXiXGyLCSd6uLhSM5aXyR8Itfu1GQyF5Q+ENGN5mR4urrSohXAqAmUCWjBmsDwmBwSPy9CCMYNNPabTpcq3V14vzsS2mHCaZaXeDk8OO9i9qyv0okN6KhEfBMoE1CcrQ3OL8k095ryi/JRbxy4VeiglXi9OxbaYcBLqeRErAmWCGluQq+mjB5pyrFtGD0rJWaGpEiglXi9Os8cfiNu2mEA0kq2eN1U+252EQJnAphbm6dcXDVa6x9XuoTO3y1C6x6W7LxqsKYUDLGqh86XShw6vF+eoqq23dH1Qaf8M3K219RafBckgWet5U6WsySkIlAlubEGu1kwboWH9syXpsEEhcvuw/tlaM21ESvc0peKHDa8XZ2BbTDgJ9bwwAysSJ4E+WRlaMmnINwvQVlTLW9t8zbBwOKzstJCKvnuCxg/NZXauUjNQStG9XgztX7S8cGAOrxcLxGu7SrbFRDTiUc87R+bWccN5CJRJJK9XN80pytcc5TfbIquTy9A9c27VkqcXa9rvfqcBObyxpW8CZTgcTslw2dbrhS3VrMe2mHCKeNbz8pmS3Hh2k1Rmukf5vbs3/fuZJx6TJxzUFVdcIUmaMGGCXU1zjFQPlAc6+PUCa7EtJpwinvW8fMYkNz5tUoTL5dKTTz4pSYTKg6TSxBw4R+GgHC0pqbJkqJFtMRGtZK3n5XM9/giUKYRQ2dyBPZRAvI0bkqtnN2615Nhsi4loJXM9b6qPPMUbgTLFECq/wYcN7BTZFnPDllpTeyndLkPD+mczkQpRoZ4XZmEKYAqKhMqJEyfqiiuu0JIlS+xuki3ooYTd2BYTdovU81qJet7UQKBMUYRKAiXsx7aYcILCQTmWrkNJPW9q4CtDCmP4ez8CJew0tiBXNXv8und1RczHYltMdEQy1vPyuR5/BMoUl8qhkh5KOMXUwjz16Jqu2SvLFQiF21VT6XYZ8rgMzSvKJ0yiQ5K1npc6+fgiUCJlQyUfNnCSsQW5Ov2EHpq5okzrN9fI7TIO+cc9cvuw/tlaMGYww9yIyYIxgzVy0VpTA6XHZWjWD/JMOx6cjUAJSakZKumhhNOwLSbsEqnnnbG8zLyDfvCSBh57ngYNGqTCwkKddtppKigo0Le+9S253W7zzgNHIFCiSaqFSgIlnOrgbTGffvl1Tb91hv78zhqd1P8YZszCEmbX8351xEDN/JO0adMmbd68WY899pgkqUuXLpo3b56mT58e83ngHHwqoZlUC5USgRLOlpnu0bEZYTXuqNCgXuyxDmuZWc/bePrP9eCDD2rnzp0KBoNN92toaFC3btb2rPO5Hn8sG4QWUmVJIXooAaClsQW5WjNthIb1z5akwy4pFLl9WP9srZk2omlyWFpamm677bYW9eqXXnqprr32Wgta3hx18vHFV120KhV6KvmwAYDWmVXPe80112jOnDn66quv5HLt78P64IMP9NFHH+nEE0+Mz8UgLgiUaFOyh0p6KAHg0A6u5z3xtBH6wQ+L9LOfXqd+2YcvwejatatuuOEG3XXXXerWrZtee+01/exnP9OQIUP07LPP6uKLL47TlcBqDHnjkA4e/n7++eftbpJpCJQAEL3MdI982yvUNzOk/N7do67nveGGG/S9731Py5cv11lnnaWNGzfqBz/4gS655BLdfvvtzeorkbjoocRhRUJlOBzW5ZdfLkkaP368za2KHYESANrH5/MpI6N9a5727NlTGzZsaPp3165d9eKLL6qgoEAzZszQ3//+d/3+979XVlaWae3kcz3+CJSIisvl0uLFiyUpqUKlxAcPAEQjHA53KFC2xjAM3XLLLTr55JM1duxYffe739Xy5ct18sknx97QA86B+GHIG1GLhMorr7xSl19+ecIPf/NhAwDR27t3rySZEigjRo0apQ8++EDdu3fXsGHD9MILL5h2bMQXPZRol2TqqWTIGwCi19DQIMncQClJ/fr103vvvafJkydr3Lhx+tvf/qaFCxfK4yGiJBKeLbRbsoRKAiUARM/n80kyP1BGjvncc8+poKBAN998s/7xj3/oxRdfVE5OjunngjUY8kaHJMPwN4ESAKIXCZRdunSx5PiGYeiGG27QO++8ow8//FDf+c53VFpa2u7j1PsD+tLoqtBRuSrfvkv1/oAFrcXB6KFEhyVLTyWBEgAOz8oeygONGDFCH3zwgS6++GINHz5cjz76qCZOnHjI32lagH1Ttbx1PoU7nSaNOE3nP/SX/QuwZ2WocFCOxg3JVV4va7d9TFUESsQkkUMlk3IAIHrxCpSSdNxxx2nt2rX62c9+pquuukqlpaV64IEHlJaW1ux+2+p8mrmiTOs318jtMlrdezwsqarOpyUlVXp241YNH9BDC8YMVp8s668jlRAoEbNEDZUMeQNA9OIZKCWpc+fOevLJJ1VQUKCpU6fqX//6l1555RUdc8wxkqRlpV7NXlmuwNchsrUweaDI7Ru21GrkorWaW5SvsV/vO47YEShhikQMlQRKAIhevANlxLXXXqvBgwfr4osv1ne+8x298sor+ru/p+5dXdGh4wVDYQVDYc1YXqaaPX5NLcwzucWpiUAJ0yRaqCRQAkD07AqUkvS9731PH3zwgf7v//5P5/3sLh05eoopx713dYV6dk3XZfRUxoxACVMlWqiUCJQAEI3IOpRWzfI+nGOOOUa/e3WVznlgncyctz1rZbmGndCDmsoYEShhukQJlUzKAYDo+Xw+paWlye1229aGOX/8WGGXWzpMvWR7BEJhzVxRpiWThph2zFREoIQl2gqVgUBAd911ly644AJ997vftbOJDHkDQDuYtY93R1Xu3K31m2tMP24wFNb6zTXaXL1bA3JYUqijCJSwzMGhMhgM6o9//KNeeeUVlZaWatWqVba2j0AJANGzO1AuLfG2uTRQrNwuQ8+/79WconzTj50qCJSwVCRUhkIhXXnllU0hbvXq1dq1a5e6d+9uW9sIlHCyUCikM844Q5999lnTZIj//d//lcvl0sUXX6z777/f5hYi1dgdKIs3VVsSJqX9vZTFFdWaIwJlR7H1IiwXCoVUX18v6ZvwFggEtHLlSjub1YRACScyDEP//e9/5fV6VVOzf5jv008/ldfrbXo/AfFkZ6Dc4w/IW+ez9BzeWh/bNMaAQAnL/fznP9crr7zS7Gcul0vLli075O/V+wMq375L//B+Ycl+rEzKgZMZhqG5c+e2+Lnb7dbMmTNtaBFSnZ2Bsqq2XlZ/9Q9L2lrLl7WOYsgbljvppJPUu3dvbd++XR6PR4FAQKFQSG+99VaLYe8W+7EecJyD92ONFUPe36j3B7S1tl6NgZDSPC71y85UZjofD3a77LLLNGvWLG3ZskXhcFhut1tXXXWV+vbta3fTkIJ8Pp9tSwY1BkJJdZ5kxF8MWG7SpElNe7G+9NJL+v3vf6/t27crGAzqwQcf1KxZszq0H2u3Y0erl/fdDrcr1QNle8J7Xi9mPtrB7XZr3rx5GjduXNPP7rjjDhtbhFTW0NBgWw9lmic+A6rtOQ9fxJtL3StHXBmGodNOO02nnXaa7rnnHpWUlOjOO+/UiBEjOrwf6+6M3toz6CdaVurt0H6sqRooOxLehw/ooQVjBrPwrw0uu+wy3Xzzzdq5c6fGjRtH7yRs4/P5dOSRR9py7n7ZmTIkS4e9ja/Pcyh8EW8bNZSIO8MwNHToUK1atUplod6asbxM/kCo/bP3DJfChlszlpfp4eLKDrcnlQLlslKvRi5aqw1baiVFH943bKnVyEVrtazUa3kb0Zzb7dZNN90kwzConYSt7KyhzEz3KNfiL7S52Rlt9jBuq/NpwlMlGvXAOi0pqVLVQWFSav5FfNQD6zThqRJts3gikZMQKGGbZaVe3bu6IraDfN3LeO/qCr3YzrCTapNyHi6u7HB4D4bC8gdCMYd3tF+9P6AfXn69/vqfagW6Hc0sVNjG7mWDCgflyO2y5nPb7TJUODCn1dv4Ih4dhrxhi211Ps1eWW7qMdu7H2sqDXmbEt6/du/qCvXsmq7LOlBmgOgwrAYnsjtQjhuSq2c3brXk2MFQWPnpdSorK5PL5Wr63+///YWe/Xtth48ZDIU1Y3mZavb4NbUwz+RWOwuBEraYuaKsqWbSLO3djzVVAqUTwjuiQ30rnMzuQJnXq5uGD+ihDVtqTV3g3O0y1CNYq0vPvaDZz7ueNFrZ591gyjlS4Ys4Q96Iu8h+rGbveHDgfqzRSJVAaWV4h3kYVoPT2blsUMSCMYPlMXnY2+MytPjas5Wdnf3Nz7r30lGjJpv692HWyvKkrqkkUCLuIvuxWiGyH2t7JHOgdEp4x6FR34pEYHcPpST1ycrQXJP3255XlK/B/XtrzZo18nj2D9xmnTtFhsttaq19sn8RJ1Ai7uKxH2s0UmFSjtPCO1oyu761vZPTgGiEw2Fb16E80NiCXE0fPdCUY90yelDTMPTJJ5+sRYsWqVN2H3U5/lQZbnOrApP9iziBEnHlpP1YU2HI247wvnfvXj333HNav369JedNJlbVtybzsBrssXfvXklyRKCUpKmFefr1RYOV7nG1+0uz22Uo3ePS3RcN1pTCAc1umzJlik66aIrCoaCZzW127mT9Ik6gRFw5aT/WZA+U8Q7vX3zxhRYsWKDjjjtOV1xxhe6++25Lz50MqG9FovD59n+WOCVQSvt7KtdMG6Fh/ffXPh4uWEZuH9Y/W2umjWh1goxhGOp8wndkuNzmN1jtG0VLNMzyRlw5aT/WZA+U8QrvG8oq9fpzj+rJJ59UY2OjQqH9j33nzp0tPntii9S3mu3AYbUBOSwpBHM4MVBK+2sql0wa8s1SWxXV8ta2stRWdoYKB+Zo/NDcQ74v9vgD+uxLv6VtjnwRT7ZtGpPrauB4TtqPNdkDZbzC+wVFP1LjjpY1gOvWrdPo0aPVpUsXZWRkqEuXLk3/O9S/D3Vb586d5XIlx8BKpL7VipKEyLDaHJMnLyB1OTVQRuT16qY5Rfmao/yY9tiO5yhafu/uFp8pvgiUiCun7MeaCuIV3r976sna+EalDMNo6p00DENHHnmkunfvroaGBu3cuVMNDQ1qaGiQz+dr+u/Iv9ujc+fOMQfTaH+3U6dOlk3eikd96xwRKGGOyPvU7mWDopGZ7ulwWHPSKFqiIVAiriL7sVZZWNt3qP1YD5TsPZTxCu+rX12q7d67NGPGDC1fvlxut1vhcFjnnXeeHnjggcMeIxwOy+/3txo4Wwufh7utvr5eNTU1bd63sbEx6utzuVym9rBG/i1PetzqW5NtWA32cHoPpVmcNIqWaPikQdwVDsrRkpIqy4b62tqP9WDJHijjGd7z8vL06quv6v3339fNN9+sjRs3qnv36HoIDMNQ586d1blzZx111FGWtTUiGAw2C6IdDa6R/9XV1emzzz5r876RXtsDdco5Xr2vesjS60zWYTXYI1UCJaNoHUegRNxZvR/r+KHRbW2V7IFSin94Hzp0qN577z299957+p//+R/Tz2kGt9utrl27qmvXrpafKxwOa9++fS3C6L8++0ozi+ssP38yDqvBHg0NDZKSP1A6aRQt0SRfnyscL7Ifq9kLbrtdhoYP6BH1zNZUCJTjhuRaWqfXWng3DENnnHGGevToYcl5E4lhGEpLS1P37t119NFHq3///srPz9f/fvvEuJw/GYfVYI9U6aGU9n8Rt3JDiGhH0RINnzawhVX7sS4YM9jUYyY6p4R3NBcZVrNSsg6rwR6JNCknVnZ8EU8GBErYwqr9WPtkRf/tORV6KCXCuxNFhtWslKzDarCHz+dTenq63G5rFvx2Er6IdwyBErYxZT/Wr8PggfuxRitVAqUTwjtaYlgNicTn86VE72QEX8Tbj0AJW8WyH6vCIRnhYKv7sUYjVQKlZFJ4/1pHwjtaYlgNicTn86VE/WQEX8Tbj0AJ23V0P9Zuvu06YdMLHQ43qRQopdjCu9tlKN3j6nB4R0sMqyGRpFqglPgi3l4ESjhCZD/Wt286UxOG9FXf7IwWkxYMSX2zMzRhSF+tmXamBn62WmmNu+1obsLqaHgf1j9ba6aNSPoPxHhjWA2JIhUDpcQX8fagYhuOcvB+rL955veaM+8ulZZs1Ak5R5g6ySDVeigjIuG9cuduLS3xqriiWt5aX7OFfA3tn9RRODBH44fm0ttlkciw2ozlZaYdM9mH1WCPhoaGlAyU0v4v4qef0EMzV5Rp/eYauV3GIctVIrcP65+tBWMGp8z7kUAJx8pM9+jo9IAad1Qov3d302cXpmqgjDg4vG+trVdjIKQ0j0v9sjOZIRwnYwtyVbPHr3tXV8R8rFQYVoM9UrWHMoIv4ofHXww4mpVhL9UD5YEy0z1s0WejqYV56tE1XbNXlisQCrdrso7bZcjjMjSvKJ8wCcukeqCMOPCL+M7aL3X8SafpiCOz9M7bb6X8F3FqKOFokbAXCX9mIlDCSahvhZOl2rJB0XjkN4vUsL1SOz8s0a6t5SkdJiV6KOFwVgZKwGkYVoNT+Xw+HXvssXY3wzF27NihhQsXStr/92nhwoV67bXX7G2UzQiUSAj0UCKVUN8Kp2HIu7lZs2Zp3759kvb/DVm5cqUqKyuVl5dnc8vsw5A3HI0aSqS6SH3rKblHKb93d8IkbEGg/EZ5ebmeeuopBYPBpp+53W4tWrTIxlbZj0AJRyNQAoD9CJTfuO+++xQOh9WpUydJksvlUiAQ0NNPP62vvvrK5tbZh6+6cLRwOGxZ/SSBEgCik8rrUB7s+uuvV//+/VVfX69f//rXOv3005Wbm6suXbo0hcxURKCEo1kZKAEA0WGW9zcKCgpUUFAgn8+nX//615o8ebLGjRtnd7Nsx5A3HI8eSgCwTygUooeyFT6fT5J4XL5GoISjMeQNAPbau3evJILTwQiUzREo4WgESgCwF8GpdTwuzREo4WjM8gYAexGcWsfj0hyBEo7GpBwAsBfBqXU8Ls0RKOF4DHkDgH0ITq1raGiQxOMSQaCEo1FDCQD2Iji1jqDdHIESjkagBAB7EZxax+PSHIESjkagBAB7RYITC5s3x+PSHIESKYvJPgBwePTEtc7n86lz585yuYhSEoESDhePWd70UAJA2+iJa53P5yNkH4BACUdjyBsA7OXz+ZSeni632213UxyFQNkcgRKORqAEAHsRnFrH49IcgRKORqAEAHs1NDQQnFrh8/koAzgAgRKOZ3WgBAC0jZ641vG4NEeghKPFo/eQHkoAaBvBqXU8Ls0RKOFoDHkDgL0Y2m0dpQDNESjhaARKALAXPXGt43FpjkAJRyNQAoC9CE6t43FpjkAJx2NSDgDYh+DUOh6X5giUcDQm5QCAvQhOreNxaY5ACUdjyBsA7MXkk9YRKJsjUMLRCJQAYC+CU+t4XJojUMLRCJQAYC+WDWodgbI5AiUczcqwx6QcADg8glNLwWBQfr+fx+UABEo4ntXBjx5KAGgbgbKlhoYGSeJxOQCBEo7GkDcA2CcUCmnv3r0Ep4P4fD5JBMoDESjhaARKALAPPXGtI1C2RKCEoxEoAcA+BMrWRR4XJit9g0AJR2NSDgDYh5641vG4tESghOMxKQcA7EFwah2PS0sESjgaQ94AYJ9IcGJotzkCZUsESjgagRIA7ENwah2PS0sESjhaPGooCZQA0DqCU+t4XFoiUMLR4tFDCQBoHcGpdZHHpXPnzja3xDkIlHA8JuUAgD0IlK2L7B5Ex8Q3CJRwNGooAcA+rLfYOrajbMljdwOAg1VVVamoqEi7d+/WF198oT179igvL08ul0u//OUvNX78eFPOQ6AEgEPz+Xzq3LmzXC76nw5EoGyJQAnH6dy5sz7++GM1NjY2/Wzz5s2SpPr6etPOQ6AEgEMjOLWOx6UlvnLAcXr16qXJkyfL7XY3/cwwDB1zzDG68sor7WsYAKQYn8/HcHcrCJQtESjhSDNmzGg2xBIOhzV79mylp6ebdg56KAHg0AhOrWtoaOBxOQiBEo7Uu3dvTZ48uSn0HXvssZo4caKp5yBQAsChEShbx+PSEoESjjVjxoym0Dd79mylpaWZenwCJQAcGsGpdTwuLREo4VjHHnuszjzzTHXp0kVXXHGF6ccnUALAoTG02zpqS1tiljccq94f0ENLVqh+r1+VNQ3ql+1SZnpyvGTr/QFtra1XYyCkNI9L/bIzk+baACQPeuJax+PSEn/B4CiVO3draYlXxZuq5a3z6cC+Q0NSblaGCgflaNyQ3JjPFe8eyvZcW16vbnFpEwAcis/nU48ePexuhuMQKFsiUMIRttX5NHNFmdZvrpHbZSgYahnywpKq6nxaUlKlZzduVbdjR6uX990OnzNegbIj1zZ8QA8tGDNYfbL4wAJgH4Z2W0egbIkaSthuWalXIxet1YYttZLUauA6UOT23Rm99Z9BP9GyUm+HzhuPQNnRa9uwpVYjF63t8LUBQEft27dPH374oT755BPt2rVLHo9HwWDQ7mY5CoGyJQIlbPVwcaVmLC+TPxA6bNhqwXApbLg1Y3mZHi6ubPe5rQ6UsVxbMBSWPxDq8LXFW70/oPLtu/QP7xcq375L9f6A3U0C0EFz585Vfn6++vfvrw8//FCLFy+Wx+PREUccoU2bNtndPEcgULbEkDdss6zUq3tXV8R2kK9D4b2rK9Sza7ouK4i9ttIMplzb15x2bRHUhALJ6eyzz9b8+fNb/NzlcqlXr142tMh5CJQt0UMJW2yr82n2ynJTjzlrZbm21fmivr9VPZROuDYrbavzacJTJRr1wDotKalS1UFhUmpeEzrqgXWa8FSJY9oP4NDOOussnXTSSc12KzMMQ3PmzNGRRx5pX8McIhAIaN++fdSWHoRACVvMXFGmQHuHuA8jEApr5oqyqO9vVaB0wrVZhZpQIPkZhqEZM2YoFAo1/axPnz766U9/amOrnMPn2//lODMz0+aWOAuBEnFXuXO31m+uaX/N5GEEQ2Gt31yjzdW7o7q/FYHSKddmhVSqCYW1qLl1vksuuUS9e/du+vfChQtN360sUTU0NEgSQ94HoYYScbe0xNvm8jmxcrsMPf++V3OK8g97344Eyh07dmjdunX60Y9+pPT09Ba3O+XazJYKNaGwFjW3iaVTp0664YYbNGPGDPXr10+XXnqp3U1yjEgPJYGyOXooEXfFm6otCVzS/p6w4opqS44tSb/73e80duxY9e3bV4888oj8fn+z2xP52tqS7DWhsBY1t4nr2muvVc+ePXXPPfc0fQEHgbItBErE1R5/QF6L/1B4a33tGkJrTw9lMBiUy+XSzp07NXXq1GbB0onXZoZkrgmFtai5TVz1/oC2N7j01t826VvDRlGWcAACZesY8kZcVdXWt+idMFtY0o8mXKMue2ujuv/DDz+s119/Par7VlRUNAXQcDisnTt3asqUKbr55pt1z+LfKyxra4zCkrbW1iu/d3dLzxMRqQk124E1oQNyGN5MRg8XV3a4TCIYCisYCmvG8jLV7PFramGeya1DayhLiA6BsnUESsRVYyB0+DuZIOxyt2uIJtr7tnU/wzAUjFOHf7weQyl5a0JhLWpuEwvbw7ZPJFCybFBzBErEVZonPqHrwfvvi6oXz+Px6Prrr9d1110X1XHnz5+vWbNmNfVSHnPMMZo1a5YmTpyozbV79UD5X2JqdzTi9RhK8akJnaNvAmU4HNYbb7yhRx99VDfddJNGjhxpyblhHatqboed0CMlw4vVlpV6NXtleVNZS3vLEuYW5WtsioV9eihbRw0l4qpfdqasLu02vj6PFdxut0KhkI455hg9+uij+uSTT3TdddcpPT094a/tYPGsCQ0EAnrhhReUn5+vCy64QKtWrdL7779v6blhDWpuEwdLgXUMgbJ19FAirjLTPcrNylCVhUElNztDmenRvbQNw2jXpJwrrrhC/fv314UXXthi2SCnXVus4lXvesu8hVr+1G+0c+fOppICt9stl8ulYDAot9ttcStgFmpuEwdlCR3n8/nkcrlYl/MgBErEXeGgHC0pqbKsLq9wYE7U929voDzmmGMOuR6bk64tVvGq1Xzqmd+pcedOSd/MuA8Gg7rjjjt0xx13NH1wp6WlKT09vem/nfQzj8fDsiqyr+a2oqJC3bp10zHHHGP6eZMRZQmxiezjzXu+OQIl4m7ckFw9u3GrJccOhsIaPzT6b8ntDZSH46Rri1W8ajXHXnqJXnnyAe3du7fZVm9XXnmlzjzzTDU2NqqxsVF+v7/pvw/8X2s/37NnT1T3i/w8GAzGfB12htto7tupU6dmezNbIZ41t+FwWOvXr9eCBQv01ltvady4cXr++ectOXeysbIsYcmkIaYe14kigRLNESgRd3m9umn4gB7asKXW1D8+bpehYf2z2zUkZnagdNK1xSpSE2rlsLch6ZG75+qB2dO1cOFCLVq0SIFAQMFgUGeccYYmTpxo4dm/EQwGtW/fvkOGz/YE2oN/1tZ9vvrqq6iPt2/fvpiv0+PxmBpSD/yZu3OmvHXHmfBstM1b69PuhkateXOV5s+frw8++EBu9/4VHQ78MoK2UZYQOwJl6wiUsMWCMYM1ctFaU0OXx2VowZjBph2vo5Ll2uJZE5qZfpR+9atf6YYbbtC8efO0ePFi9enTx7LzHsztdsvtdqtz585xO2d7hcPhQ4beaENwe3/m8/miOqeR1UdH/XihtY+BpOO+dYq+qvqw6WfBYFCGYej//b//pzlz5qhz587q3Lmz0tPTW/3vQ92Wnp6e9OULLAUWOwJl6wiUsEWfrAzNLcrXjOXmzdycV5Tf7vods3soJedcmxniXRMamT3/m9/8Rh4PH08HMgyjqUfQif7h/UJjHt1g+XlcnpbXHw6HVVVVpcWLF2vv3r3y+/3au3evAoH27+7icrmiCp7RBtSO3K9Tp06Whdp4LwWWjBoaGgiUreATG7YZW5Crmj3+2GYahsOSYeiW0YM6NMPQikApmXRtX+votZnBrprQTp06WXJOWCdeNbdri99R6eoVuuOOO1RdXa1wOCyPx6OJEyfqgQceaHbfYDDYFC4PDJqt/bsj96utrW12vwNvj/x/Y2Njh67TivCqTp3lrbM2CEWWAovXahR2oIeydcn7jCMhTC3MU4+u6U0L67brm3M4JCMc0q8vPqXDgcuqQCnFdm1ulyGPy9C8onxbl+JIpppQWCteNbcn5ByhkyZN0k9+8hM99NBDuuuuu7R79+4Wy3hJ+0sZMjIybP3jHwqF5Pf7ow6p7Qm0e/fu1ZdffnnY+/r9fklSp5zj1fuqhyy93nhvD2sHAmXrCJSw3diCXJ1+Qo/Dbv0VEbm9m2+7ennf1WUFF3b43FYGSqnj1zasf7ZjtjVLlppQWCve67B26dJFt956q6655ho9/vjjOv/88y07byxcLpe6dOli6zZ9oVBIjY2NKv2kRhOe+5fl54vn9rB2IFC2jkAJR+iTlaElk4aocuduLS3xqriiWt5aX7PeDkP7/6AUDszR+KG5uu36K9XQ2GBXk6PWkWtzUs9dMtWEwlp2rMN61FFHacaMGaafL5lE6kKzusfncyWe28PawefzKSsry+5mOA6BEo6S16ub5hTla47yVe8PaPL0X+hfZeVa9sLz6pedaXpdjtU9lAc6+Nq21tarMRBSmsdlybWZKVlqQmGtZFqHNRnFqywhXtvD2oUeytY59y8YUlZtba0efPBB+f1+ffje26r+7DM99+ACSdLll1+u/HzzZhDGM1AeKDPdk3A1RslQEwprUXPrbMm2PaxdCJStS+5nHQnpP//5j+68886mXT3C4bDuv/9+BQIBHXPMMUkRKBNVMtSEwlrU3DpbMm0PaxcCZeuSu9ABCamgoECnnXZa0+4X4XBYgUBAXbt21ZVXXmn6+QiU7ROpCX37pjM1YUhf9c3O0MEr5hmS+mZnaMKQvloz7UwtmTSEMJkiIjW3ZqLm1jzjhuRaug5lKpQlEChbRw8lHMcwDN11110aPXp0089cLpemT5+uI4880vRzoWMSuSYU1qLm1rkoS4gdgbJ19FDCkUaOHNnUSylJGRkZuvHGG00/D0Pe5ojUhJ6Se5Tye3cnTEJTC/P064sGK93jktvVvi9ubpehdI9Ld180WFMKB1jUwtS1YMxgedr5nBxOqpQlhMNhAmUbCJRwpEgvZSTsWdE7GTkPgRKwxtiCXK2ZNkLD+mdL0mGDZeT2Yf2ztWbaCHomLUJZQsft27dPwWCQQNkKuhHgWCNHjlSvXr303//+15LeSYlACVgt0ddhTVaUJXRMQ8P+tY8JlC0RKOFYvsagHnlhpbZu+1Sf+Qx16mLN/rAESsB61Nw6D0uBtZ/Pt3/JJQJlS7yD4ShNvRibquWti/RipOs3H/9lfy9GVoYKB+Vo3BBzPsDooQTiLxHXYU1WLAXWPgTKthEo4Qjb6nyH/UALS6qq82lJSZWe3bhV3Y4drV7ed2M6L7O8AaQ6yhKiR6BsG4EStltW6m0acpF02GGXyO27M3prz6CfaFmpV2M7OORCDyUA7EdZwuERKNvGqwO2eri4suNF4YZLYRmasbxMNXv8mlqY1/5DECgBoAXKEloXCZRdunSxuSXOw7JBsM2yUm/sMwy/HrK+d3WFXiz1dugQBEoAQDTooWwbgRK22Fbn0+yV5aYec9bKcm2r87Xrd+ihBABEi0DZNgIlbDFzRVlTzaRZAqGwZq4oa9fvMCkHABAtAmXbCJSIu8qdu7V+c42p+8hK+yfrrN9co83Vu6P+HXooAQDR8vl88ng86tSpk91NcRwCJeJuaYm33Xv7RsvtMvT8+9HXUhIoAQDRYh/vthEoEXfFm6pN752MCIbCKq6obtfvECgBANEgULaNQIm42uMPyNvOiTPt5a31qd4fiOq+9FACAKJFoGwbgRJxVVVbL6vjW1jS1tr6qO7LpBwAQLQaGhoIlG0gUCKuGgMhR52HHkoAQLTooWwbgRJxleaJz0su2vMQKAEA0SJQto1Aibjql50pqweZja/PEy0CJQAgGgTKthEoEVeZ6R7lZln7ZszNzlBmenTb1NNDCQCIFoGybQRKxF3hoBxL16EsHJgT9f2ZlAMAiJbP51OXLl3sboYjESgRd+OG5Fq6DuX4oblR358eSgBAtOihbBuBEnGX16ubhg/oYXovpdtlaPiAHhqQ0y3q3yFQAgCiRaBsG4EStlgwZrA8JgdKj8vQgjGD2/17BEoAQDQIlG0jUMIWfbIyNLco39RjzivKV592TvihhxIAEC0CZdsIlLDN2IJcTR89MLaDfB0Gbxk9SJcVRF87GcGkHABAtAiUbSNQwlZTC/P064sGK93jan9NZTgkIxzU3RcN1pTCAR06Pz2UAIBohMNhAuUhEChhu7EFuVozbYSG9c+WpMMGy8jt3XzbdcKmFzrUMxlBoAQARKOxsVHhcJhA2QYCJRyhT1aGlkwaordvOlMThvRV3+yMFjvqGJL6ZmdowpC+WjPtTA38bLXSGnfHfG4CJQDgcHw+nyQRKNsQ3XYiQJzk9eqmOUX5mqN81fsD2lpbr8ZASGkel/plZ0a9A0606KEEAESDQHloBEo4Vma6R/m9u1t6DiblAACiQaA8NIa8kdLooQQARINAeWgESqQ0AiUAIBqRQMle3q0jUCLlESgBAIdS7w/o4517lHbMQG33uVTvD9jdJMehhhIpjR5KAEBrKnfu1tISr4o3Vctb51NY0jFX3K9rlm+RsXyLcrMyVDgoR+OG5CqvVze7m2s7AiVSGpNyAAAH2lbn08wVZVq/uUZul6FgqGWnQ1hSVZ1PS0qq9OzGrRo+oIcWjBnc7u1/kwlD3khp9FACACKWlXo1ctFabdhSK0mthskDRW7fsKVWIxet1bJSr+VtdCp6KJHyCJQAgIeLK3Xv6ooO/W4wFFYwFNaM5WWq2ePX1MI8k1vnfPRQIqXRQwkAWFbq7XCYPNi9qyv0Ygr2VBIokdIIlACQ2rbV+TR7Zbmpx5y1slzb6nymHtPpCJRIaUzKAYDUNnNFmQKHqZVsr0AorJkrykw9ptMRKJHS6KEEgNRVuXO31m+uOezkm/YKhsJav7lGm6t3m3pcJyNQIuURKAEgNS0t8crtsmakyu0y9Pz7qVNLSaBESqOHEgBSV/GmatN7JyOCobCKK6otObYTESiR0giUAJCa9vgD8lo8ccZb60uZbRoJlEhpTMoBgNRUVVsvq7sTwpK21tZbfBZnIFAipdFDCQCpqTEQSqrz2I1AiZRHoASA1JPmiU8Eitd57JYaVwm0gR5KAEhN/bIzZXXRk/H1eVIBgRIpjUAJAKkpM92j3KwMS8+Rm52hzHSPpedwCgIlUhqTcgAgdRUOyrF0HcrCgTmWHNuJCJRIafRQAkDqGjck19J1KMcPzbXk2E5EoETKI1ACQGrK69VNwwf0ML2X0u0yNHxADw3I6WbqcZ2MQImURg8lAKS2BWMGy2NyoPS4DC0YM9jUYzodgRIpjUAJAKmtT1aG5hblm3rMeUX56mPxhB+nIVAipTEpBwAwtiBX00cPNOVYt4wepMsKUqd2MiI15rIDbaCHEgAgSVML89Sja7pmryxXIBRu12Qdt8uQx2VoXlF+SoZJiR5KgEAJAJC0v6dyzbQRGtY/W5IOO1kncvuw/tlaM21EyoZJiR5KpDh6KAEAB+qTlaElk4aocuduLS3xqriiWt5anw78S2Fo/6LlhQNzNH5obkrN5m4LgRIpjUAJAGhNXq9umlOUrznKV70/oK219WoMhJTmcalfdmbK7IATLR4NpDQm5QAADicz3aP83t3tboajUUOJlEYPJQAAsSNQIuURKAEAiA2BEimNHkoAAGJHoERKI1ACABA7AiVSGpNyAACIHYESKY0eSgAAYkegRMojUAIAEBsCJVIaPZQAAMSOQImURqAEACB2BEqkNCblAAAQOwIlUh49lAAAxIa9vJFQVq9eraKiIgWDQQWDQUlSp06d5HK59PLLL6uoqKhdx2PIGwCA2BEokVD69OmjxsbGZiEwEAhIknJzc9t9PAIlAACxY8gbCeVb3/qWLrvsMnk833wX8ng8uvDCC3XyySe3+3gESgAAYkegRMKZNWtW03C3tL+Hcs6cOR06FpNyAACIHYESCSfSS2kYhgzD6HDvZAQ9lAAAxIZAiYQ0a9YshcNhhcPhDvdOSgx5AwBgBiblICF961vf0tChQ7V3796YeicNw1AoFDKvYQAApCACJRJSvT+gxa++qcZASOXbd6lfdqYy09v3cq73B+TP6Kl9wXCHjwGgpXp/QFtr69UYCCnN4+K9BaQAI8x4HxJE5c7dWlriVfGmannrfDrwhWtIys3KUOGgHI0bkqu8Xt0sOwaAlnhvAamNQAnH21bn08wVZVq/uUZul6FgqO2XbOT24QN6aMGYweqTlWHaMQC0xHsLgESghMMtK/Vq9spyBULhQ/6hOpjbZcjjMjS3KF+SYj7G2IL2L5oOJDsz3p+8t4DkQKCEYz1cXKl7V1fY3QxJ0vTRAzW1MM/uZgCOYdb7k/cWkBxYNgiOtKzU65gwKUn3rq7Qi6Veu5sBOIKZ70/eW0ByIFDCcbbV+TR7ZbndzWhh1spybavz2d0MwFZWvD95bwGJj0AJx5m5okyBdtRjxUsgFNbMFWV2NwOwlRXvT95bQOIjUMJRKnfu1vrNNe0q8I+XYCis9ZtrtLl6t91NAWxh1fuT9xaQ+AiUcJSlJV65XYbdzWiT22Xo+fep90JyeuWVV/TUU0+psbGx1dutfH/y3gISG4ESjlK8qdqRvZMRwVBYxRXVdjcDsMScOXN09dVX6/jjj9cTTzzRIlha+f7kvQUkNgIlHGOPPyBvAhTme2t9qvcH7G4GYJkdO3Zo8uTJzYJlPN6fvLeAxMXmqnCMqtp6Obdv8hthSaeOOEeuXdvtbgpgqi1btkiSIssTb9++XZMnT9aNN96otf/+j+Xvz7CkrbX1yu/d3eIzATAbgRKO0RgI2d2EqA0bPkLZ4a/sbgZgqmeffVa1tbVN/zaM/fWSp556qlyetLi0IZE+BwB8g0AJx0jzJE4FxvRpN9KLgqTz5ptvqra2Vm63W5J01VVXaebMmerXr5/Kt++KSxsS6XMAwDcIlHCMftmZMiTHD3sb2t9WINlkZGTI7XZr4sSJuuOOO9SvX7+m2+Lx/uS9BSQuAiUcIzPdo9ysDFU5fGJObnaGMtN56yD5vPjii3K73crNzW1xWzzen7y3gMTF2AIcpXBQjuPXoSwcmGN3MwBLHH/88a2GyQgr35+8t4DERqCEo4wbkuv4dSjHD237Dy6QzKx8f/LeAhIbgRKOkterm4YP6OHIXkq3y9DwAT00IKeb3U0BbGHV+5P3FpD4CJRwnAVjBsvjwEDpcRlaMGaw3c0AbGXF+5P3FpD4CJRwnD5ZGZpblG93M1qYV5SvPlkZdjcDsJUV70/eW0DiI1DCkcYW5Gr66IF2N6PJLaMH6bIC6rsAydz3J+8tIDkY4cgeW4ADLSv1avbKcgVC4XZNBnC7DHlchuYV5SssxXwM/uABLZnx/uS9BSQHAiUcb1udTzNXlGn95hq5XcYh/3BFbh8+oIcWjBncNIxmxjEAtMR7C4BEoEQCqdy5W0tLvCquqJa31tdsxw5D+xdFLhyYo/FDc9ucLWrGMQC0xHsLSG0ESiSken9AW2vr1RgIKc3jUr/szHbvsGHGMQC0xHsLSD0ESgAAAMSEWd4AAACICYESAAAAMSFQAgAAICYESgAAAMSEQAkAAICYECgBAAAQEwIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJgQKAEAABATAiUAAABiQqAEAABATAiUAAAAiAmBEgAAADEhUAIAACAmBEoAAADEhEAJAACAmBAoAQAAEBMCJQAAAGJCoAQAAEBMCJQAAACICYESAAAAMSFQAgAAICYESgAAAMSEQAkAAICYECgBAAAQEwIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJgQKAEAABATAiUAAABi8v8BRZ0v/RMgHKoAAAAASUVORK5CYII="
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# get node dataset from data service\n",
     "centerville_epn_link = '5b1fdc2db1cf3e336d7cecc9'\n",
@@ -165,41 +128,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "start_time": "2023-10-23T14:57:26.735406Z",
      "end_time": "2023-10-23T14:57:26.887482Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dataset already exists locally. Reading from local cached zip.\n",
-      "Unzipped folder found in the local cache. Reading from it...\n",
-      "Dataset already exists locally. Reading from local cached zip.\n",
-      "Unzipped folder found in the local cache. Reading from it...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/lz/cytsgpz97f34yd69304b9vyc0000gr/T/ipykernel_12874/3196477836.py:18: FionaDeprecationWarning: This function will be removed in version 2.0. Please use CRS.from_epsg() instead.\n",
-      "  NetworkUtil.build_link_by_node(node_filename, graph_filename, id_field, out_filename)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": "True"
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# this process can be done using the local shapefile, \n",
     "# instead of using the dataset from the incore data service.\n",
@@ -230,39 +166,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "start_time": "2023-10-23T14:57:30.115378Z",
      "end_time": "2023-10-23T14:57:30.191292Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dataset already exists locally. Reading from local cached zip.\n",
-      "Unzipped folder found in the local cache. Reading from it...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/lz/cytsgpz97f34yd69304b9vyc0000gr/T/ipykernel_12874/1565815967.py:20: FionaDeprecationWarning: This function will be removed in version 2.0. Please use CRS.from_epsg() instead.\n",
-      "  NetworkUtil.build_node_by_link(link_filename, link_id_field, fromnode_field, tonode_field, out_node_filename, out_graph_filename)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": "True"
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# this process can be done using the local shapefile, \n",
     "# instead of using the dataset from the incore data service.\n",
@@ -308,23 +219,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "start_time": "2023-10-23T14:57:33.444367Z",
      "end_time": "2023-10-23T14:57:34.943261Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "network dataset is created with id 6536d02dfaa0854c4fb04416\n",
-      "attching files to created dataset\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dataset_prop = {\n",
     "  \"title\": \"Test epn network\",\n",

--- a/manual_jb/content/notebooks/create_network_dataset/create_network_dataset.ipynb
+++ b/manual_jb/content/notebooks/create_network_dataset/create_network_dataset.ipynb
@@ -17,13 +17,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "ExecuteTime": {
-     "start_time": "2023-10-23T14:56:54.196461Z",
-     "end_time": "2023-10-23T14:56:55.335895Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import ast, os\n",
@@ -35,22 +30,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "ExecuteTime": {
-     "start_time": "2023-10-23T14:56:56.525730Z",
-     "end_time": "2023-10-23T14:57:06.236064Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Connection successful to IN-CORE services. pyIncore version detected: 1.12.0\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "client = IncoreClient()\n",
     "datasvc = DataService(client)"
@@ -65,24 +47,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "ExecuteTime": {
-     "start_time": "2023-10-23T14:57:10.022062Z",
-     "end_time": "2023-10-23T14:57:10.181272Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dataset already exists locally. Reading from local cached zip.\n",
-      "Unzipped folder found in the local cache. Reading from it...\n",
-      "network_graph.csv successfully created.\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# get link dataset from data service\n",
     "centerville_epn_link = '5b1fdc2db1cf3e336d7cecc9'\n",
@@ -113,34 +80,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
-    "scrolled": true,
-    "ExecuteTime": {
-     "start_time": "2023-10-23T14:57:15.586709Z",
-     "end_time": "2023-10-23T14:57:15.782454Z"
-    }
+    "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dataset already exists locally. Reading from local cached zip.\n",
-      "Unzipped folder found in the local cache. Reading from it...\n",
-      "{0: (-97.4745, 35.266), 1: (-97.4745, 35.2626), 2: (-97.4873, 35.2626), 3: (-97.4873, 35.196), 4: (-97.4836, 35.196), 5: (-97.4369, 35.196), 6: (-97.4838, 35.2509), 7: (-97.5113, 35.2509), 8: (-97.5023, 35.246), 9: (-97.4903, 35.2567), 10: (-97.4964, 35.2604), 11: (-97.49950726683866, 35.2427), 12: (-97.4691, 35.2427), 13: (-97.47226381921406, 35.246689303630674), 14: (-97.48874482954297, 35.23152065345497), 15: (-97.4888, 35.2165), 16: (-97.4768, 35.2165), 17: (-97.4888, 35.2101), 18: (-97.4601, 35.2509), 19: (-97.46507448011698, 35.25914896023397), 20: (-97.4442, 35.259), 21: (-97.4466, 35.2406), 22: (-97.4466, 35.2305), 23: (-97.4691, 35.2312), 24: (-97.3976, 35.2045), 25: (-97.3964, 35.2311), 26: (-97.40211901205474, 35.23360380241095), 27: (-97.4021, 35.2561), 28: (-97.4112, 35.2398), 29: (-97.41233569457059, 35.21449438614856), 30: (-97.43521617501703, 35.215086558444916), 31: (-97.4656664519788, 35.21571961356189)}\n",
-      "DiGraph with 32 nodes and 30 edges\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": "<Figure size 640x480 with 1 Axes>",
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAApQAAAHzCAYAAACe1o1DAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAABfEklEQVR4nO3de3hU1d328XvPDAkkIJpAUJSASOCpKT5qG6EoYiqgVRuL+igtoCIqWqiKRUVsOSm04gGt1iMeKmLxBBaLVURToIJpak95o5JQJIOCpEkUIRMmzOH9AycSksAks/fsPTPfz3X1qmQme689p9yz1m+tZYTD4bAAAACADnLZ3QAAAAAkNgIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJgQKAEAABATAiUAAABiQqAEAABATAiUAAAAiAmBEgAAADEhUAIAACAmBEoAAADEhEAJAACAmBAoAQAAEBMCJQAAAGJCoAQAAEBMCJQAAACICYESAAAAMSFQAgAAICYESgAAAMSEQAkAAICYECgBAAAQEwIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJgQKAEAABATAiUAAABiQqAEAABATAiUAAAAiAmBEgAAADEhUAIAACAmBEoAAADEhEAJAACAmBAoAQAAEBMCJQAAAGJCoAQAAEBMCJQAAACICYESAAAAMSFQAgAAICYESgAAAMSEQAkAAICYECgBAAAQEwIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJh47G4AgEOr9we0tbZejYGQ0jwu9cvOVGY6b10AgHPwVwlwoMqdu7W0xKviTdXy1vkUPuA2Q1JuVoYKB+Vo3JBc5fXqZlczAQCQJBnhcDh8+LsBiIdtdT7NXFGm9Ztr5HYZCobafntGbh8+oIcWjBmsPlkZcWwpAADfIFACDrGs1KvZK8sVCIUPGSQP5nYZ8rgMzS3K19iCXAtbCABA6wiUgAM8XFype1dXxHyc6aMHamphngktAgAgeszyBmy2rNRrSpiUpHtXV+jFUq8pxwIAIFoESsBG2+p8mr2y3NRjzlpZrm11PlOPCQDAoRAoARvNXFGmQDvqJaMRCIU1c0WZqccEAOBQCJSATSp37tb6zTXtmoATjWAorPWba7S5erepxwUAoC0ESsAmS0u8crsMS47tdhl6/n1qKQEA8UGgBGxSvKna9N7JiGAorOKKakuODQDAwQiUgA32+APyWjxxxlvrU70/YOk5AACQCJSALapq62X1ArBhSVtr6y0+CwAABErAFo2BUFKdBwCQ2giUgA3SPPF568XrPACA1MZfG8AG/bIzZc387m8YX58HAACrESgBG2Sme5SblWHpOXKzM5SZ7rH0HAAASARKwDaFg3IsXYeycGCOJccGAOBgBEokpHp/QOXbd+kf3i9Uvn1XQi6PM25IrqXrUI4fmmvJsQEAOBjjYUgYlTt3a2mJV8WbquWt8zVbdseQlJuVocJBORo3JFd5vbrZ1cyo5fXqpuEDemjDllpTg6XbZWhY/2wNyHH+YwAASA5GOBy2ejk8ICbb6nyauaJM6zfXyO0yDhm+IrcPH9BDC8YMVh+L6xRjta3Op5GL1spv4vI+6R6X1kwb4fhrBwAkD4a84WjLSr0auWitNmyplaTD9uRFbt+wpVYjF63VslJn72fdJytDc4vyTT3mvKJ8wiQAIK4IlHCsh4srNWN5mfyBULuHhIOhsPyBkGYsL9PDxZUWtdAcYwtydcaAbFOOdcaAHrqsgNpJAEB8ESjhSMtKvbp3dYUpx7p3dYVedHBP5bJSr/6yudaUY/1lc42jrxUAkJwIlHCcbXU+zV5ZbuoxZ60s17Y6n6nHNEMqXSsAIHkRKOE4M1eUKWDycjqBUFgzV5SZekwzpNK1AgCSF4ESjlK5c7fWb64xfX3GYCis9ZtrtLl6t6nHjUUqXSsAILkRKOEoS0u8lu4e8/z7LesLw+Gw1qxZo7ffftuS87bFjmsFAMAKBEo4SvGmakt3jymuqG76dzgc1ttvv62hQ4dq1KhRuu666yw5b1viea0AAFiJQAnH2OMPyGvxZBJvrU979u5rCpKjR4/WBx98IEkKBoOWnvtA8brWRNySEgCQeNh6Ec3U+wPaWluvxkBIaR6X+mVnKjM9Pi+Tqtp6Wb1tU1hS3qnD9PlHf2v6WSRI7ty5U2effbbFLdjPn9FT4W9PsPQcYUlba+uV37u7pecBAIBACcfskd1o4vaDh9Kt+1H6XJJhGDpw51GXy6WcnJy4tGF3WrY+jcN54vWYAgBSG4EyhUWzR3ZYUlWdT0tKqvTsxq2W7pGd5olPBcaKV19W484tmjNnjlauXCmPx6NAIKCePXvq97//fVzaUL59l85/6C+WnydejykAILXx1yZFOXGP7H7ZmbJmzvM3jK/Pc8opp+gPf/iD/v73v+u8886TJKWnp1t89m/E81oBALAaPZQp6OHiyg5vaxgMhRUMhTVjeZlq9vg1tTDPtHZlpnuUm5WhKgsnq+RmZzSrCY0Ey3/9619qbGy07LwHs+NaAQCwCj2UKcbpe2QXDsqxdG3GwoGt10j+7//+rwoKCiw5b1vsulYAAMxGoEwhibBv9LghuZauzTh+aK4lx+6IZLzWen9A5dt36R/eL1S+fRfLFgFAimA8LIVYuW/0kklDTDleXq9uGj6ghzZsqTU1bLldhob1z9aAHOtmqbdXslyrU1YJgL3LfgFIbUb4wHVTkLQqd+7WqAfWWXb8NdPONC3AbKvzaeSitfKbuORNuselNdNGWDI7PRaJfK3RrBIQEbndylUCUhWBHoATMOSdIhJp3+g+WRmaW5Rv2vEkaV5RviNDTKJeqxNXCUg12+p8mvBUiUY9sE5LSqpUdVCYlJov+zXqgXWa8FSJqSUqABBBoEwRibZv9NiCXE0fPdCUY90yepAuK3BO7eTBEu1aHy6u1IzlZfIHQu1+TQVDYfkDIc1YXqaHiystamHyI9ADcBoCZQpI1H2jpxbm6dcXDVa6x9Xu3lW3y1C6x6W7LxqsKYUDTG2XFRLlWp2+SkAqINADcCICZQqI1x7ZW2vrTT/u2IJcrZk2QsP6Z0vSYcNW5PZh/bO1ZtoIR/dMHszp15oIqwQkOwI9AKdiUk4K+If3C415dIPl51lx/TCdknuUZcdvmnxQUS1vbSuTD7IzVDgwR+OH5jpqNndHOPFaJzxVYtmMdLNWCUhmiTyBC0DyI1CmgHjtG73qZ2cov3d3y88j7V8e5ZKJ16uhMaDf/uaBpF4exQlLwSTSKgHJikAPwMkY8k4BybhvdGa6Rxn+OmX4diq/d/ekDZPS/mvN791dp+QeZdu1JtIqAcmocudurd9cY/rEumAorPWba7S5erepxwWQegiUKSCyb7SV2Dc6uSXaKgGJxufzac2aNQoEWp/YRqAH4HQEyhTBvtHoqERdJSCRvPrqqxo1apQGDRqkF154QcFgsNntBHoATkegTBHJuG804iNeqwT85V+b9Mknn6iqqkrbtm3TZ599ps8//1zV1dWqqalRXV2dvvzyS3311Vfas2ePfD6f/H6/9u3bp2AwqEQuB29oaJAkffLJJxo3bpxOPPFEvfzyywqFQgR6AAmBMcoUYeW+0QW5R+iEnl1NOyacpdHEWcWHUvSji9S4I/YlcVwul1wul9xud9N/t/a/Q90ey+925BgVFfuvOxKKKyoqdOmllyorK0u/emxJ3Jb9itekOgDJh0CZQhaMGayRi9aaGijDwYBeve0SZdy0S/n5+crPz9egQYM0aNAgFRQUKDf30D2XTpjBjENL88RnIOOJRx/RcV2lUCjU7H/BYLDFzzpyHzOO1dZth/qdQCBw2ONt37691cekrq5O5R9tkmTOTkqHEq8vDgCSE3+5U0hk3+gZy8tMO+aNpx+jm+/5r/aGQvrggw/0z3/+U5IUDAZ15JFH6osvvmjxO01rLG6qlreulTUWszJUOChH44bkKq8XS8nYLbJKgJW9ZIakS84dkbJfJh566CHdeOONCofDcrvdcrvduu6663TrrbfqS6Or/hCHZb/i9cUBQHJKzU/vFDa2IFc1e/ym7LZxy+hBmlI4QJ/efLPuu+8+hcPhpskEhmFoypQpze6/rc6nmSvKtH5zjdwuo9We0rCkqjqflpRU6dmNWzV8QA8tGDOYhZdtFFkloMrCOr5UXyUgHA4rHA6rc+fOmjJliqZPn66jjz5aknSkPxCXQB/PZb8AJB++kqYgs/eNvv3229W1a/Mayp49e2rGjBlN/15W6tXIRWu1YUutJB122D1y+4YttRq5aK2WsUWcrVglwFoXXXSRFi1aJK/Xq3vvvbcpTEos+wW0V70/oPLtu/QP7xcq376LCWdxwidIihpbkKvTT+hx2B7DiMjtw/pnt+gxzMrK0syZMzVz5kyFw2F5PB7V1dXpjDPO0NKlS1VcndbhHtFgKKxgKKwZy8tUs8evqYV5HToOYjNuSK6e3bjVkmOzSoB03HHH6aabbmrz9sJBOVpSUmXJSg0EeiQDSqnsx9aLMGXfaJ/Pp+OPP17V1dV64oknVFBQoHHjxqnuqP9R+vCrTGvr3RcN1mUF+8PHxRdfrIaGBr3xxhumHR9tY+s/+7D1JdC6aEqpIiK3U0plDQIlmoll1vWbb76pdevWaf78+TIMQ5Xb63T+IxvVGDz870Yr3ePSmmkj1Ccrg0AZZ9vqfBq5aK38Js4GPvD5xKER6IHmlpV6NXtluQJfj2RFy+0y5HEZmluUr7EFqT06YiZqKNFMLPtGn3vuuVqwYIEMY3+t3bw/VSoYNrfuLhAKa+YK82apI3qRVQLMNK8onzAZpQVjBstjch2rx2VowZjBph4TiIeHiys1Y3mZ/IFQu79kBUNh+QMhzVhepoeLKy1qYeohUMISlTt3a/3mGtNrvoKhsNZvrtHm6t2mHhfRGVuQq+mjzVkT8ZbRg5rKF3B4BHpgv2WlXlNWKpGke1dX6EUmfZqCQAlLLC3xWjor+Pn3+QCwi9mrBCB6BHqkum11Ps1eWW7qMWetLNc2i7c3TQUESliieFO1pXuHF1dUW3JsRGdsQa7WTBuhYf2zJemwwTJy+ynHZOjtm84kyMSAQI9UNnNFmQIm/22hlMocLBsE0+3xB+S1+Nuet9anowxevnbqk5WhJZOGRL1KwDkDMjQsv7+qfvddvfXWW8rKyrKr6QnPzGW/gEQRKaUy24GlVKx20HHM8obpyrfv0vlx2CruW1WvyfjyM2Z5O8ihVgn49NNP1adPH0lSr1699PLLL2v48OF2NjcpmLHsF5AI5qwst3Q91glD+mqOyXXKqYQuHpiu0cRlZQ4lbLhlTZUmOiqySkBrPJ5vPm6qq6s1YsQIzZ49W3fccUez29A+eb26aU5RvuYoP6ZlvwCni0cp1RwRKDuKGkqYLs0Tn5eVETZxgUtYzu12N/13ZO/quXPnasSIEfL5KIg3QyzLfgFOFq9SKrZp7DgCJUzXLzvT8p5DQ1J641cWnwVmaq0X0jAM/b//9/9UU2N+XRSA5FFVWy+r6/PCkrbW1lt8luRFoITpMtM9yrW46D83O0PuMN8kE8mBgTKy+P0tt9yiqqoq5eYy6xtA2+JVShWv8yQjAiUsUTgox9J1KAsH5lhybFinU6dOcrlcSktL01VXXSWPx6OsrCwdeeSRdjcNgMPFq5QqXudJRjxysMS4IbmWFk+PH0qPVqLp3Lmz1qxZo08++USLFy/WNddco7vvvlu7du2yu2kAHC5epVT9sjMtPkvyIlDCEnm9umn4gB6m91K6XYaGD+jB8icJqrCwUL1795Yk3XHHHfL5fFq0aJHNrQLgdPEqpWIiW8cRKGGZBWMGy2NyoPS4DC0YM9jUY8Iexx57rH7605/q/vvvV21trd3NAeBwlFI5G4ESljm6Wyed23O3qcecV5TPLh9J5LbbblMoFNLChQvtbgoAh6OUytkIlDBVOBzWxo0bNWXKFB111FH6zY2XKa/hY1OOfcvoQewBnWRycnJ000036aGHHtKOHTvsbg4AB6OUytkIlDDFp59+ql/84hfq27evhg0bpscee0z19fvX83rw2h/o1xcNVrrH1e4PArfLULrHpbsvGqwphQOsaDpsNn36dKWnp+tXv/qV3U0B4HCUUjkXgRKmmDlzpubPn69t27ZJkkKh/Wt5nXDCCTrxxBM1tiBXa6aN0LD+2ZJ02GAZuX1Y/2ytmTaCnskkduSRR2r69Ol6/PHH5fV67W4OAAfrk5WhuSbvt00plTkIlDDFggUL1L9/f7lc37ykPB6P/u///q/p332yMrRk0hC9fdOZmjCkr/pmZ7RYBsKQ1Dc7QxOG9NWaaWdqyaQhvNFTwI033qgjjjhCd955p91NAeBwYwtyNX30QFOORSmVeYxwOGz1bkZIEa+//rouvPBCHfiSev/99zVkyJA2f6feH9DW2no1BkJK87jULzsz6mUbLr74YjU0NOiNN96Iue2w3/33369bb71VH330kfLy8uxuDgCHW1bq1eyV5QqEwu2arON2GfK4DM0ryidMmohACVP87W9/09lnn638/Hzt2rVLH374oXr27KnPP/+8Wa+lmQiUyaWhoUEDBgzQWWedpaVLl9rdHAAJYFudTzNXlGn95hq5XcYhg2Xk9uEDemjBmMGMfpmMFTwRs3//+98aPXq0TjzxRL311lsKBAK65JJLNGLECMvCJJJPly5d9Mtf/lI//elPdfvtt+vb3/623U0C4HCRUqrKnbu1tMSr4opqeWt9OjBWGtq/aHnhwByNH5rLbG6L0EOJmHz88cc688wzddxxx+ndd9+N677M9FAmn8bGRg0aNEinnHKKli9fbndzACSgen9Aw865UB9XbNbbb/1J3xmYyw44cUD3ETrsP//5j84++2z16tVLq1evjmuYRHJKS0vTnDlztGLFCn3wwQd2NwdAAvqsaov+vfYNNe6o0IqnHyJMxknK91DGMikklXm9Xg0fPlydO3fW2rVrdfTRR8e9DbH0UPK8O1cgENC3v/1tHX/88frTn/7U9HOeMwDRmDBhgl544QWFQiGlpaWpqqrKlr9RqSYlP42bai02Vctb10qtRVaGCgflaNyQXOX1otbiYNu3b9f3v/99ud1uvfPOOwnzRuV5Twwej0fz5s3TZZddphXvvq9/7enGcwYgKhUVFVq6dGnTaiPBYFALFy7U/fffb3PLkl9K9VAyGyx21dXVGjFihPbs2aP169erX79+trUl2h5KnvfEU1WzRz++f6W2h7vznAGI2oQJE7Rs2TIFAoGmn6Wnp2vr1q0J0/mRqFKmhnJZqVcjF63Vhi21knTYNasit2/YUquRi9ZqWSk7eNTV1WnUqFH68ssv9e6779oaJqPF8554lpV6NfrB9dppHCmJ5wxAdD777DO98MILCgaDTSuMuN1u+f1+/fa3v7W5dckvJYa8Hy6u1L2rKzr0u8GvF0ydsbxMNXv8mlqYmgsu79q1S+ecc462b9+uP//5zwmx8DTPe+LhOQPQUd26ddPUqVO1e/du/fOf/9THH3+ssWPHKhwOa8SIEXY3L+kl/ZD3slKvZiwvM+14d180OOVW1t+zZ4/OOeccffjhh3r33Xd1yimn2N0kSYce8uZ5Tzw8ZwDMcuedd+qRRx7Rjh077G5KykjqIe9tdT7NXllu6jFnrSzXtjqfqcd0soaGBhUVFamsrExvvvmmY8LkofC8Jx6eMwBIbEkdKGeuKFOgHft7RiMQCmvmCvN6UZzM7/froosuUklJiVatWnXIPbmdhOc98fCcAUBiS9pAWblzt9ZvrmnXhvHRCIbCWr+5Rpurd5t6XKfZt2+fxo4dq+LiYv3hD3/Q8OHD7W5SVHjeEw/PGQCzJXk1nyMlbaBcWuKV22VYcmy3y9Dz7zefSRoOh/Xaa6/p/PPPV3m5uUN38RYMBnX55Zdr1apVevXVVzVy5Ei7mxS1eD/vOLyXXnpJY8eObXPnG54zAFYwDGs+V9C6pA2UxZuqTe/xiAiGwiquqJb0TZA86aSTNGbMGL3xxhv629/+Zsl54yEUCunqq6/Wyy+/rGXLlun888+3u0ntEq/nHdF7++239eKLL+q73/2uLrjgghbBkucMABJfUi4btMcfkNfiYnxvrU/PvfCi7p4/Tx9++GHTmlfS/tpDny/xJgOEw2FNmzZNv/vd7/TUU0/p3HPPdfR1BAIBBYPBpjbWx+l5/++XXykzLSnfOpYIBALyeDwKBAJ68803tWrVKp177rmaNWuWBp9aEJfnrN4fYJtGALBQUi4bVL59l85/6C+Wn2f70z/TvupPLD8PotMp53j1vuohy8/D826eRc+8rAc2dbH8PKt+dobye3e3/DwAnGHevHl67LHHtH37drubkjKS8it7YyAUl/Oc+t3T9Nc/bZVhGAqFvjnnddddpzPPPDMubTDLSy+9pNdee01XXnmlRo8ebXdzorJo0SI1NjbqtttukyR5fW49utn689654NfKzQhaf6Ik8eSTT2rt2rVN7xHDMJSWlqYLL7xQQ08/Q9rUem2lmeL1mQAAqSopA2WaJz6loU89+bjSfXfprrvu0pIlS2QYhoLBoIYOHaof//jHcWmDGebPn6/XXntN99xzj6ZPn253c6L2yiuvqKGhoemxLt++S4/GoWf6gh+cQ29XO7z77rv685//LJfLpS5duujnP/+5brrpJh111FEq374rLm2I12cCAGdIwsFXx0vKT9l+2Zmyem6X8fV5BgwYoGeffVabNm3S+PHj5Xa7lZOTY/HZzXP//ffrF7/4hebNm5dQYbI18XzeEb2cnBxlZmbqF7/4hbZt26a5c+fqqKOOksRzBsA6zPKOr6QMlJnpHuVmZVh6jtzsjGZF/pFguWfPHp177rmWntssjzzyiH7+85/r9ttv1y9+8Qu7mxMzO553HN68efNUW1vbLEhG8JwBQHJIykApSYWDcixd265wYOu9kJ07d06Ib0XPPPOMpkyZohtvvFHz589PiDZHw67nHW1zu91KS0tr83aeMwBIfEkbKMcNybV0bbvxQ3MtOXY8/P73v9ekSZM0efJkLVq0KGnCpMTznoh4zgAg8SVtoMzr1U3DB/QwvecjHAyox77/qmd6Ys4aXbFihSZMmKAJEybokUceSaowKVn3vLtdhoYP6KEBOd1MPS54zgCYj0k58Ze0gVKSFowZLI+Jf6TC4bDchlT5wjx961vf0vLly007djy88cYbuuyyy3TxxRfrqaeearYYezIx+3mXJI/L0IIxg009Jr5hyXtVYZ4zIIUlW4eJ0yVnovhan6wMzS3KN+14hmHov2/+Vv933vd16qmn6uKLL9aYMWP06aefmnYOq7zzzju66KKLdN555+n555+Xx5O8kxTMft4laV5RvvpYPHkklVnxXq19+zGV/3WdaccEALQtqQOlJI0tyNX00QNNOdaXa5/Tj07qpWeffVZ79+7V008/rffff18nnniifvvb3yoYdOZi13/5y19UVFSks846Sy+++KI6depkd5MsZ+bzfsvoQbqswPl1ePX+gMq379I/vF+ofPsu1fsDdjepXcx8zm4sPF6nH23oggsu0LPPPmvKMQEAbUvebqoDTC3MU4+u6Zq9slyBULhdEwDcLkMel6E5PzxRxbXdtXjxYt16661avHixtmzZoldeeUVLlizR1KlT9fzzz+uJJ57Q4MHOGWb761//qvPOO0+nnXaali9frvT0dLubFDdmPO/zivIdHSYrd+7W0hKvijdVy1vn04FXaEjKzcpQ4aAcjRuSq7xezq8lNPM5+9n3l2vKlCmaOHGitm3bpl/84hcMgQGARZK+hzJibEGu1kwboWH9syXpsBMAIrcP65+tNdNG6Men9dVjjz2mq6++WgsXLtTtt9+uI444Quecc45GjRqldevW6csvv9Spp56qO+64Qw0NDZZf0+H885//1DnnnKNvf/vbev3115WRkXpDtrE+704Nk9vqfJrwVIlGPbBOS0qqVHVQmJSksKSqOp+WlFRp1APrNOGpEm2r89nR3HYx6znzeDx67LHHdOedd2rWrFmaPHmyAoHE6rUF0DFMyok/I5yCj3pTr05Ftby1rfTqZGeocGCOxg/NbTFDNBQK6brrrtPixYv12GOP6Z133tFLL72kX/7yl7r99tu1cOFCzZ8/X/369dPjjz+uwsLCpt/1+XwqLy9XQUGB5df44YcfasSIEerbt6/eeecdde+efFsFXnzxxWpoaNAbb7wR1f1jed6dZFmpN6YevLlF+Rrr0KB8MLOes2eeeUbXXHONfvCDH2jZsmXKzGTnHCCZzZ49W08//bS2bdtmd1NSRkoGygPV+wPaWluvxkBIaR6X+mVnHnZXjQND5dNPP60dO3bojjvu0A9/+EMtWbJEn332ma699lr95S9/0cSJE3XPPfcoOztbP/7xj7Vs2TJt3LhRQ4cOtayNlZWVOvPMM9WzZ08VFxcrOzs76nMlkvYGygPV+wM68bQR+vy/NfrTqtc15MT+CbGbysPFlbp3dUXMx5k+eqCmFuaZ0KL46ch79UBvvvmmLrnkkqYe+549e1rYWgB2IlDGn/P/glosM92j/N7t671zuVx67LHHJElXXXWVnnnmGb3++uv6yU9+oqFDh+q1117T2rVrm+ot//jHP+qqq67SsmXLZBiGJk+erL///e9yu91tnqOjtXFbt27V2WefrSOPPFJr1qxJ2jAZq3+Uvi/vvzdIkl5+YpG+/+ijNrfo8JaVek0Jk5J07+oK9eya7tgh/dZ05L16oHPPPVdr167Veeedp2HDhunNN9/UCSecYGILASB1pUwNpdkiofLqq6/WxIkTVVNTo7/+9a8KhUI67bTTtHr1al177bX66KOPdPrpp+vuu++WtL+u49///rcef/zxVo8bS23cZ599prPPPludOnXSmjVrlJPDlnNtmTVrVtMEjcWLF8vr9drcokPbVufT7JXlph5z1sryhKipNNN3vvMdbdy4UYZh6Hvf+55KS0vtbhIAJAUCZQwODpXvv/++SkpKdMYZZ+i8887TwoULdfTRR6t///4tZpfedtttqq6ubvazZaVejVy0Vhu21ErSYevjIrdv2FKrkYv+rBFXzdS+ffv07rvv6thjjzXxSpPLhg0bVFxc3FS0HQ6HNX/+fJtbdWgzV5QpYPL2hIFQWDNXlJl6zETQv39/bdiwQSeccILOOuusDpVMAHC2FK/mswWBMkYHh8rXXntNf/jDH3T77bfrtttu0w9/+EPdf//9LV7ce/bs0dVXX93074eLKzVjeZn8gVC79zUOhsLyB8IKnHqpJt3/svr27WvKtSWrWbNmNSs3CAaDevrpp1VVVWVjq9pWuXO31m+uMX2/62AorPWba7S5erepx00EPXr00DvvvKORI0eqqKhITz/9tN1NAmAylgmLLwKlCQ4Olc8//7zmz5+vl156Se+++666deumfv36qWvXrs1+7/XXX9d//vMfU2vjnvmgRi+WOnv41k4VFRV65513FA6Hm7aedLvdCgQCTXWxTrO0xGv6PtcRbpeh599PzddLRkaGXn31VV1zzTWaNGmS5s6dS68GAHRQyk/KMcuBE3UmTpwoSbriiis0cOBA/ehHP9KePXv0xz/+UQUFBdqxY4e8Xq8+/vhjdTryaM1+1tzt4WatLNewE3qwVWArjjvuON13332qr6/Xu+++q7///e+67bbbZBiGioqK7G5eq4o3VZveOxkRDIVVXFGtOTJ3q8pE4fF49Mgjj6hPnz6644479Omnn+rRRx9N6q1JAcAKfGqaqK1QWVpaqksvvVQjR47Ugw8+qOuvv14nnHCCCgsLNeGpEstq45ZMGmLqcZNBRkaGbr75ZklSIBBQZWWlZs6caXOr2rbHH5DX4okz3lqf6v2BhFg2yQqGYWjmzJk69thjdfXVV2vHjh168cUXWasSANqBIW+THTz8/bvf/U49evTQW2+9pZ/+9KeaMmWKrr32Wvn9fmrjbGYYhuOHOKtq61vM8jdbWNLW2nqLz+J8V1xxhVatWqW1a9eqsLCwxaQ5AInD6Z/tyYhAaYHWQmWnTp304IMP6umnn9Zzzz2n73//+3qi+CNq42yUCAXbjYFQUp3H6UaPHq21a9fK6/Vq2LBh2rx5s91NAtBBifAZn0wIlBaJhMpJkyY1hUpp/1D42rVr9cknn+il9eWW18bh0Jz+LTbNE5+3aLzOkwhOPfVUbdy4UW63W8OGDdNf//pXu5sEAI7HXxELuVwuPf744y1C5dChQ7V2Q4mMbtZu/RapjUPrEmHIu192pqz+jm18fR584/jjj9d7772nAQMGqLCwUKtWrbK7SQDgaARKi7UVKhvTjpAs7o6nNu7QEiFQZqZ7lGvxbP3c7IyUnZBzKJG1KkePHq0LL7xQixcvtrtJAOBY/BWJg0iolL6Z/X1SYXyWqKE2rm2JECglqXBQjpaUVFlSHuF2GSocyBadbenSpYteeeUV3XDDDbrmmmv06aefavbs2dRmAcBBCJRxcnCoXPDoc5KOsvy81Ma1LVFCwbghuXp241ZLjh0MhTV+aK4lx04WbrdbDz/8sI477jjNnDlT27Zt02OPPaZOnTrZ3TQAbUiEzoJkQ6CMowND5R03XKs+N78kWVghR23c4SXCh05er24aPqCHNmypNbWX0u0yNKx/tgbkdDPtmMnKMAzdfvvtOvbYYzVp0iTt2LFDL730UovdrwA4R6J0GiQLuq/iLBIqr7p8nPZ98bml56I27tASZchbkhaMGSyPyUtMeVyGFowZbOoxk93ll1+uVatWaf369axVCQAHIFDaIBIq+3f2KRwKWnIOauMOL5ECZZ+sDM0tMnd7xHlF+WzP2QGjR4/WunXr9Omnn+p73/ueKisr7W4SANiOQGkTl8ulxTOukOFyW3L8YCisof2z9A/vFyrfvovlg1qRaMMhYwtyNX30QFOOdcvoQbqs4JvayXp/QOXbd/F6idIpp5yijRs3qlOnTho2bJhKSkrsbhIA2IrxUBsNOrq7zhiQrfcq/6uwYX62v27p35v+25CUm5WhwkE5GjckV3m9qJtLpB7KiKmFeerRNV2zV5YrEAq3q6bS7TIUDgZ09clHaErhAFXu3K2lJV4Vb6qWt87XbItHXi+H169fP7333nsqKipSYWGhXnrpJV1wwQV2NwuAEqM+PtnQQ2mzX405SWmdPJLFL/6wpKo6n5aUVGnUA+s04akSbavzWXrORJCIHzpjC3K1ZtoIDeufLUmH3b4zcvuw/tna9ti1mn3dWA2f9aJGPbBOS0qqVHVQmJR4vUQrOztba9as0bnnnqsLL7xQTzzxhN1NAvC1RBuFSnQESps11cbF6YUf6dHasKVWIxet1bLS1N3vOxF7KCP6ZGVoyaQhevumMzVhSF/1zc5osV6AIalvdoYmDOmrNdPO1JJJQ3TqD36sY65+RN69nSXpsD2cvF4Or0uXLnr55Zd1/fXXa/LkyZo1a1bCvq4AoKMY8naAsQW5qtnj172rK/b3VMYhXAa/Hi6dsbxMNXv8mlqYZ/k5nSaRA2VEXq9umlOUrznKV70/oK219WoMhJTmcalfdmazWf4PF1dqZ7+RMsLhdn9z5/VyaG63Ww899JD69OmjGTNm6NNPP9Xjjz/OWpUAUgaB0iEOrI1r3BewpKayLfeurlDPrunNJmmkgmQbDslM9yi/d/dWb1tW6t3/hUWxX3eqvl4OxzAM3XbbbTr22GM1ceJE7dixQy+//DJrVQJICQx5O0ikNu70vJ6SZNmSQq2ZtbI85WrkkqGHMhrb6nyavbLc1GOm4uslWuPHj9cbb7yh9957T2eddZZ27txpd5OAlJMKn+1OQ6B0mD5ZGXp+0lC9deMZyt27VfvqtkstpkyYLxAKa+aKMsvP4zSp8KEzc0WZAibvA56qr5dojRo1SuvWrdP27dv1ve99TxUVFXY3CUg5yTYK5XQESocadHR3rV00VT8Ilmjb/Zfq+uO/1Irrh+nRcadacr5gKKz1m2u0uXq3Jcd3olTooazcuVvrN9eYumWjlJqvl/Y6+eSTtXHjRqWnp2vYsGF6//33m257+umntX79ehtbBwDmIlA6mMvl0hNPPKGJE36i26+boLI/v66SLXWHXSamo9wuQ8+/nzqzeBM9UIZCIZ177rm69dZb9d///rfV+ywt8fJ6sVHfvn313nvv6X/+53/0/e9/XytXrtQjjzyiSZMm6Zprrkno1x8AHIhA6XCRUHnVVVfpyiuv1Mq//cf03qaIYCis4orU2Zs40YdD/H6/3nrrLd1zzz3Kzc1tNVgWb6rm9WKzrKwsvf322/rBD36gH/3oR5oyZYokadOmTdqwYYPNrQMAczDLOwFEQmXA8Ki40WXpqkLeWp/+U/WpMtKs2RLSTA0NDdq7d6927NjRod//6quvFAqFOvz7dmtoaGj677179+q+++7Tb37zG1111VWaMWOGsnr1ltfiiTPeWp/q/YFmyxOhpS5duuimm27Sa6+91tQr6fF49Nhjj+n0008/5O8ebjkoAHACI8yYS8L4f59+qQt++57l59n+9M+0r/oTy88D6xxxxBHa8JFX5z/0F8vPtepnZ7S5XBH227Jli0499VTt3r1boVCo6eedOnXS559/rqysrGb3Z1tMIDa33367XnzxRW3ZssXupqQMvuYmkH0WDV0e7P4HH9LxCfA3av78+WpsbNTcuXM79PsrV67UM888oxUrVpjcsvjw+/26+OKLm/7tcrkUCoV00kknae7cuWoMhA7x2+aJ13kS2ZYtW+Tz+RQKheTxeBQIBCRJ+/bt05NPPqnbbrtN0v4lnmauKNP6zTVyu4xWyxUO3Bbz2Y1bNXxADy0YM1h9sjLieUmA4yV6WVOiIVAmkDRPfEpeC89MjB6np59+Wg0NDTr//PM79PtbtmyRy+Xq8O/bLTLkHZlcNGLECM2bN09nnHGGJKl8+664tCNer8tENnLkSH3xxRdav3693n77bf3pT3/SRx99JEn61a9+pdtuu03LSr2avbK8aYmn9m6LObcoX2NZbB6ATQiUCaRfdqYMWbsqpfH1eVJBon977dSpk3JycpSfn98sSEbwenGWzMxMnXvuuTr33HN133336fPPP9dzzz2n3bt36+HiyqadjNqLbTERL9Tz4lB4JSSQzHSPcrMyVGXhRIvc7IyU+YBI9GWDPB7PIXdh4fXibEcffbRuvfVWLSv1asZycxaJZ1tMmI16XkSLsaoEUzgox9J1BQsH5lhybCdK9EAZDV4vzsa2mHCqbXU+TXiqRKMeWKclJVWqOihMSs3reUc9sE4TnipxzGsv2T/bnYhAmWDGDcm1dF3B8UNTq2cj2T90eL04G9tiwomWlXo1ctFabdhSK6n99bzLSp2x4UGilzUlGgJlgsnr1U3DB/QwvdfJ7TI0fEAPDchJnSGLVOih5PXiXGyLCSd6uLhSM5aXyR8Itfu1GQyF5Q+ENGN5mR4urrSohXAqAmUCWjBmsDwmBwSPy9CCMYNNPabTpcq3V14vzsS2mHCaZaXeDk8OO9i9qyv0okN6KhEfBMoE1CcrQ3OL8k095ryi/JRbxy4VeiglXi9OxbaYcBLqeRErAmWCGluQq+mjB5pyrFtGD0rJWaGpEiglXi9Os8cfiNu2mEA0kq2eN1U+252EQJnAphbm6dcXDVa6x9XuoTO3y1C6x6W7LxqsKYUDLGqh86XShw6vF+eoqq23dH1Qaf8M3K219RafBckgWet5U6WsySkIlAlubEGu1kwboWH9syXpsEEhcvuw/tlaM21ESvc0peKHDa8XZ2BbTDgJ9bwwAysSJ4E+WRlaMmnINwvQVlTLW9t8zbBwOKzstJCKvnuCxg/NZXauUjNQStG9XgztX7S8cGAOrxcLxGu7SrbFRDTiUc87R+bWccN5CJRJJK9XN80pytcc5TfbIquTy9A9c27VkqcXa9rvfqcBObyxpW8CZTgcTslw2dbrhS3VrMe2mHCKeNbz8pmS3Hh2k1Rmukf5vbs3/fuZJx6TJxzUFVdcIUmaMGGCXU1zjFQPlAc6+PUCa7EtJpwinvW8fMYkNz5tUoTL5dKTTz4pSYTKg6TSxBw4R+GgHC0pqbJkqJFtMRGtZK3n5XM9/giUKYRQ2dyBPZRAvI0bkqtnN2615Nhsi4loJXM9b6qPPMUbgTLFECq/wYcN7BTZFnPDllpTeyndLkPD+mczkQpRoZ4XZmEKYAqKhMqJEyfqiiuu0JIlS+xuki3ooYTd2BYTdovU81qJet7UQKBMUYRKAiXsx7aYcILCQTmWrkNJPW9q4CtDCmP4ez8CJew0tiBXNXv8und1RczHYltMdEQy1vPyuR5/BMoUl8qhkh5KOMXUwjz16Jqu2SvLFQiF21VT6XYZ8rgMzSvKJ0yiQ5K1npc6+fgiUCJlQyUfNnCSsQW5Ov2EHpq5okzrN9fI7TIO+cc9cvuw/tlaMGYww9yIyYIxgzVy0VpTA6XHZWjWD/JMOx6cjUAJSakZKumhhNOwLSbsEqnnnbG8zLyDfvCSBh57ngYNGqTCwkKddtppKigo0Le+9S253W7zzgNHIFCiSaqFSgIlnOrgbTGffvl1Tb91hv78zhqd1P8YZszCEmbX8351xEDN/JO0adMmbd68WY899pgkqUuXLpo3b56mT58e83ngHHwqoZlUC5USgRLOlpnu0bEZYTXuqNCgXuyxDmuZWc/bePrP9eCDD2rnzp0KBoNN92toaFC3btb2rPO5Hn8sG4QWUmVJIXooAaClsQW5WjNthIb1z5akwy4pFLl9WP9srZk2omlyWFpamm677bYW9eqXXnqprr32Wgta3hx18vHFV120KhV6KvmwAYDWmVXPe80112jOnDn66quv5HLt78P64IMP9NFHH+nEE0+Mz8UgLgiUaFOyh0p6KAHg0A6u5z3xtBH6wQ+L9LOfXqd+2YcvwejatatuuOEG3XXXXerWrZtee+01/exnP9OQIUP07LPP6uKLL47TlcBqDHnjkA4e/n7++eftbpJpCJQAEL3MdI982yvUNzOk/N7do67nveGGG/S9731Py5cv11lnnaWNGzfqBz/4gS655BLdfvvtzeorkbjoocRhRUJlOBzW5ZdfLkkaP368za2KHYESANrH5/MpI6N9a5727NlTGzZsaPp3165d9eKLL6qgoEAzZszQ3//+d/3+979XVlaWae3kcz3+CJSIisvl0uLFiyUpqUKlxAcPAEQjHA53KFC2xjAM3XLLLTr55JM1duxYffe739Xy5ct18sknx97QA86B+GHIG1GLhMorr7xSl19+ecIPf/NhAwDR27t3rySZEigjRo0apQ8++EDdu3fXsGHD9MILL5h2bMQXPZRol2TqqWTIGwCi19DQIMncQClJ/fr103vvvafJkydr3Lhx+tvf/qaFCxfK4yGiJBKeLbRbsoRKAiUARM/n80kyP1BGjvncc8+poKBAN998s/7xj3/oxRdfVE5OjunngjUY8kaHJMPwN4ESAKIXCZRdunSx5PiGYeiGG27QO++8ow8//FDf+c53VFpa2u7j1PsD+tLoqtBRuSrfvkv1/oAFrcXB6KFEhyVLTyWBEgAOz8oeygONGDFCH3zwgS6++GINHz5cjz76qCZOnHjI32lagH1Ttbx1PoU7nSaNOE3nP/SX/QuwZ2WocFCOxg3JVV4va7d9TFUESsQkkUMlk3IAIHrxCpSSdNxxx2nt2rX62c9+pquuukqlpaV64IEHlJaW1ux+2+p8mrmiTOs318jtMlrdezwsqarOpyUlVXp241YNH9BDC8YMVp8s668jlRAoEbNEDZUMeQNA9OIZKCWpc+fOevLJJ1VQUKCpU6fqX//6l1555RUdc8wxkqRlpV7NXlmuwNchsrUweaDI7Ru21GrkorWaW5SvsV/vO47YEShhikQMlQRKAIhevANlxLXXXqvBgwfr4osv1ne+8x298sor+ru/p+5dXdGh4wVDYQVDYc1YXqaaPX5NLcwzucWpiUAJ0yRaqCRQAkD07AqUkvS9731PH3zwgf7v//5P5/3sLh05eoopx713dYV6dk3XZfRUxoxACVMlWqiUCJQAEI3IOpRWzfI+nGOOOUa/e3WVznlgncyctz1rZbmGndCDmsoYEShhukQJlUzKAYDo+Xw+paWlye1229aGOX/8WGGXWzpMvWR7BEJhzVxRpiWThph2zFREoIQl2gqVgUBAd911ly644AJ997vftbOJDHkDQDuYtY93R1Xu3K31m2tMP24wFNb6zTXaXL1bA3JYUqijCJSwzMGhMhgM6o9//KNeeeUVlZaWatWqVba2j0AJANGzO1AuLfG2uTRQrNwuQ8+/79WconzTj50qCJSwVCRUhkIhXXnllU0hbvXq1dq1a5e6d+9uW9sIlHCyUCikM844Q5999lnTZIj//d//lcvl0sUXX6z777/f5hYi1dgdKIs3VVsSJqX9vZTFFdWaIwJlR7H1IiwXCoVUX18v6ZvwFggEtHLlSjub1YRACScyDEP//e9/5fV6VVOzf5jv008/ldfrbXo/AfFkZ6Dc4w/IW+ez9BzeWh/bNMaAQAnL/fznP9crr7zS7Gcul0vLli075O/V+wMq375L//B+Ycl+rEzKgZMZhqG5c+e2+Lnb7dbMmTNtaBFSnZ2Bsqq2XlZ/9Q9L2lrLl7WOYsgbljvppJPUu3dvbd++XR6PR4FAQKFQSG+99VaLYe8W+7EecJyD92ONFUPe36j3B7S1tl6NgZDSPC71y85UZjofD3a77LLLNGvWLG3ZskXhcFhut1tXXXWV+vbta3fTkIJ8Pp9tSwY1BkJJdZ5kxF8MWG7SpElNe7G+9NJL+v3vf6/t27crGAzqwQcf1KxZszq0H2u3Y0erl/fdDrcr1QNle8J7Xi9mPtrB7XZr3rx5GjduXNPP7rjjDhtbhFTW0NBgWw9lmic+A6rtOQ9fxJtL3StHXBmGodNOO02nnXaa7rnnHpWUlOjOO+/UiBEjOrwf6+6M3toz6CdaVurt0H6sqRooOxLehw/ooQVjBrPwrw0uu+wy3Xzzzdq5c6fGjRtH7yRs4/P5dOSRR9py7n7ZmTIkS4e9ja/Pcyh8EW8bNZSIO8MwNHToUK1atUplod6asbxM/kCo/bP3DJfChlszlpfp4eLKDrcnlQLlslKvRi5aqw1baiVFH943bKnVyEVrtazUa3kb0Zzb7dZNN90kwzConYSt7KyhzEz3KNfiL7S52Rlt9jBuq/NpwlMlGvXAOi0pqVLVQWFSav5FfNQD6zThqRJts3gikZMQKGGbZaVe3bu6IraDfN3LeO/qCr3YzrCTapNyHi6u7HB4D4bC8gdCMYd3tF+9P6AfXn69/vqfagW6Hc0sVNjG7mWDCgflyO2y5nPb7TJUODCn1dv4Ih4dhrxhi211Ps1eWW7qMdu7H2sqDXmbEt6/du/qCvXsmq7LOlBmgOgwrAYnsjtQjhuSq2c3brXk2MFQWPnpdSorK5PL5Wr63+///YWe/Xtth48ZDIU1Y3mZavb4NbUwz+RWOwuBEraYuaKsqWbSLO3djzVVAqUTwjuiQ30rnMzuQJnXq5uGD+ihDVtqTV3g3O0y1CNYq0vPvaDZz7ueNFrZ591gyjlS4Ys4Q96Iu8h+rGbveHDgfqzRSJVAaWV4h3kYVoPT2blsUMSCMYPlMXnY2+MytPjas5Wdnf3Nz7r30lGjJpv692HWyvKkrqkkUCLuIvuxWiGyH2t7JHOgdEp4x6FR34pEYHcPpST1ycrQXJP3255XlK/B/XtrzZo18nj2D9xmnTtFhsttaq19sn8RJ1Ai7uKxH2s0UmFSjtPCO1oyu761vZPTgGiEw2Fb16E80NiCXE0fPdCUY90yelDTMPTJJ5+sRYsWqVN2H3U5/lQZbnOrApP9iziBEnHlpP1YU2HI247wvnfvXj333HNav369JedNJlbVtybzsBrssXfvXklyRKCUpKmFefr1RYOV7nG1+0uz22Uo3ePS3RcN1pTCAc1umzJlik66aIrCoaCZzW127mT9Ik6gRFw5aT/WZA+U8Q7vX3zxhRYsWKDjjjtOV1xxhe6++25Lz50MqG9FovD59n+WOCVQSvt7KtdMG6Fh/ffXPh4uWEZuH9Y/W2umjWh1goxhGOp8wndkuNzmN1jtG0VLNMzyRlw5aT/WZA+U8QrvG8oq9fpzj+rJJ59UY2OjQqH9j33nzp0tPntii9S3mu3AYbUBOSwpBHM4MVBK+2sql0wa8s1SWxXV8ta2stRWdoYKB+Zo/NDcQ74v9vgD+uxLv6VtjnwRT7ZtGpPrauB4TtqPNdkDZbzC+wVFP1LjjpY1gOvWrdPo0aPVpUsXZWRkqEuXLk3/O9S/D3Vb586d5XIlx8BKpL7VipKEyLDaHJMnLyB1OTVQRuT16qY5Rfmao/yY9tiO5yhafu/uFp8pvgiUiCun7MeaCuIV3r976sna+EalDMNo6p00DENHHnmkunfvroaGBu3cuVMNDQ1qaGiQz+dr+u/Iv9ujc+fOMQfTaH+3U6dOlk3eikd96xwRKGGOyPvU7mWDopGZ7ulwWHPSKFqiIVAiriL7sVZZWNt3qP1YD5TsPZTxCu+rX12q7d67NGPGDC1fvlxut1vhcFjnnXeeHnjggcMeIxwOy+/3txo4Wwufh7utvr5eNTU1bd63sbEx6utzuVym9rBG/i1PetzqW5NtWA32cHoPpVmcNIqWaPikQdwVDsrRkpIqy4b62tqP9WDJHijjGd7z8vL06quv6v3339fNN9+sjRs3qnv36HoIDMNQ586d1blzZx111FGWtTUiGAw2C6IdDa6R/9XV1emzzz5r876RXtsDdco5Xr2vesjS60zWYTXYI1UCJaNoHUegRNxZvR/r+KHRbW2V7IFSin94Hzp0qN577z299957+p//+R/Tz2kGt9utrl27qmvXrpafKxwOa9++fS3C6L8++0ozi+ssP38yDqvBHg0NDZKSP1A6aRQt0SRfnyscL7Ifq9kLbrtdhoYP6BH1zNZUCJTjhuRaWqfXWng3DENnnHGGevToYcl5E4lhGEpLS1P37t119NFHq3///srPz9f/fvvEuJw/GYfVYI9U6aGU9n8Rt3JDiGhH0RINnzawhVX7sS4YM9jUYyY6p4R3NBcZVrNSsg6rwR6JNCknVnZ8EU8GBErYwqr9WPtkRf/tORV6KCXCuxNFhtWslKzDarCHz+dTenq63G5rFvx2Er6IdwyBErYxZT/Wr8PggfuxRitVAqUTwjtaYlgNicTn86VE72QEX8Tbj0AJW8WyH6vCIRnhYKv7sUYjVQKlZFJ4/1pHwjtaYlgNicTn86VE/WQEX8Tbj0AJ23V0P9Zuvu06YdMLHQ43qRQopdjCu9tlKN3j6nB4R0sMqyGRpFqglPgi3l4ESjhCZD/Wt286UxOG9FXf7IwWkxYMSX2zMzRhSF+tmXamBn62WmmNu+1obsLqaHgf1j9ba6aNSPoPxHhjWA2JIhUDpcQX8fagYhuOcvB+rL955veaM+8ulZZs1Ak5R5g6ySDVeigjIuG9cuduLS3xqriiWt5aX7OFfA3tn9RRODBH44fm0ttlkciw2ozlZaYdM9mH1WCPhoaGlAyU0v4v4qef0EMzV5Rp/eYauV3GIctVIrcP65+tBWMGp8z7kUAJx8pM9+jo9IAad1Qov3d302cXpmqgjDg4vG+trVdjIKQ0j0v9sjOZIRwnYwtyVbPHr3tXV8R8rFQYVoM9UrWHMoIv4ofHXww4mpVhL9UD5YEy0z1s0WejqYV56tE1XbNXlisQCrdrso7bZcjjMjSvKJ8wCcukeqCMOPCL+M7aL3X8SafpiCOz9M7bb6X8F3FqKOFokbAXCX9mIlDCSahvhZOl2rJB0XjkN4vUsL1SOz8s0a6t5SkdJiV6KOFwVgZKwGkYVoNT+Xw+HXvssXY3wzF27NihhQsXStr/92nhwoV67bXX7G2UzQiUSAj0UCKVUN8Kp2HIu7lZs2Zp3759kvb/DVm5cqUqKyuVl5dnc8vsw5A3HI0aSqS6SH3rKblHKb93d8IkbEGg/EZ5ebmeeuopBYPBpp+53W4tWrTIxlbZj0AJRyNQAoD9CJTfuO+++xQOh9WpUydJksvlUiAQ0NNPP62vvvrK5tbZh6+6cLRwOGxZ/SSBEgCik8rrUB7s+uuvV//+/VVfX69f//rXOv3005Wbm6suXbo0hcxURKCEo1kZKAEA0WGW9zcKCgpUUFAgn8+nX//615o8ebLGjRtnd7Nsx5A3HI8eSgCwTygUooeyFT6fT5J4XL5GoISjMeQNAPbau3evJILTwQiUzREo4WgESgCwF8GpdTwuzREo4WjM8gYAexGcWsfj0hyBEo7GpBwAsBfBqXU8Ls0RKOF4DHkDgH0ITq1raGiQxOMSQaCEo1FDCQD2Iji1jqDdHIESjkagBAB7EZxax+PSHIESjkagBAB7RYITC5s3x+PSHIESKYvJPgBwePTEtc7n86lz585yuYhSEoESDhePWd70UAJA2+iJa53P5yNkH4BACUdjyBsA7OXz+ZSeni632213UxyFQNkcgRKORqAEAHsRnFrH49IcgRKORqAEAHs1NDQQnFrh8/koAzgAgRKOZ3WgBAC0jZ641vG4NEeghKPFo/eQHkoAaBvBqXU8Ls0RKOFoDHkDgL0Y2m0dpQDNESjhaARKALAXPXGt43FpjkAJRyNQAoC9CE6t43FpjkAJx2NSDgDYh+DUOh6X5giUcDQm5QCAvQhOreNxaY5ACUdjyBsA7MXkk9YRKJsjUMLRCJQAYC+CU+t4XJojUMLRCJQAYC+WDWodgbI5AiUczcqwx6QcADg8glNLwWBQfr+fx+UABEo4ntXBjx5KAGgbgbKlhoYGSeJxOQCBEo7GkDcA2CcUCmnv3r0Ep4P4fD5JBMoDESjhaARKALAPPXGtI1C2RKCEoxEoAcA+BMrWRR4XJit9g0AJR2NSDgDYh5641vG4tESghOMxKQcA7EFwah2PS0sESjgaQ94AYJ9IcGJotzkCZUsESjgagRIA7ENwah2PS0sESjhaPGooCZQA0DqCU+t4XFoiUMLR4tFDCQBoHcGpdZHHpXPnzja3xDkIlHA8JuUAgD0IlK2L7B5Ex8Q3CJRwNGooAcA+rLfYOrajbMljdwOAg1VVVamoqEi7d+/WF198oT179igvL08ul0u//OUvNX78eFPOQ6AEgEPz+Xzq3LmzXC76nw5EoGyJQAnH6dy5sz7++GM1NjY2/Wzz5s2SpPr6etPOQ6AEgEMjOLWOx6UlvnLAcXr16qXJkyfL7XY3/cwwDB1zzDG68sor7WsYAKQYn8/HcHcrCJQtESjhSDNmzGg2xBIOhzV79mylp6ebdg56KAHg0AhOrWtoaOBxOQiBEo7Uu3dvTZ48uSn0HXvssZo4caKp5yBQAsChEShbx+PSEoESjjVjxoym0Dd79mylpaWZenwCJQAcGsGpdTwuLREo4VjHHnuszjzzTHXp0kVXXHGF6ccnUALAoTG02zpqS1tiljccq94f0ENLVqh+r1+VNQ3ql+1SZnpyvGTr/QFtra1XYyCkNI9L/bIzk+baACQPeuJax+PSEn/B4CiVO3draYlXxZuq5a3z6cC+Q0NSblaGCgflaNyQ3JjPFe8eyvZcW16vbnFpEwAcis/nU48ePexuhuMQKFsiUMIRttX5NHNFmdZvrpHbZSgYahnywpKq6nxaUlKlZzduVbdjR6uX990OnzNegbIj1zZ8QA8tGDNYfbL4wAJgH4Z2W0egbIkaSthuWalXIxet1YYttZLUauA6UOT23Rm99Z9BP9GyUm+HzhuPQNnRa9uwpVYjF63t8LUBQEft27dPH374oT755BPt2rVLHo9HwWDQ7mY5CoGyJQIlbPVwcaVmLC+TPxA6bNhqwXApbLg1Y3mZHi6ubPe5rQ6UsVxbMBSWPxDq8LXFW70/oPLtu/QP7xcq375L9f6A3U0C0EFz585Vfn6++vfvrw8//FCLFy+Wx+PREUccoU2bNtndPEcgULbEkDdss6zUq3tXV8R2kK9D4b2rK9Sza7ouK4i9ttIMplzb15x2bRHUhALJ6eyzz9b8+fNb/NzlcqlXr142tMh5CJQt0UMJW2yr82n2ynJTjzlrZbm21fmivr9VPZROuDYrbavzacJTJRr1wDotKalS1UFhUmpeEzrqgXWa8FSJY9oP4NDOOussnXTSSc12KzMMQ3PmzNGRRx5pX8McIhAIaN++fdSWHoRACVvMXFGmQHuHuA8jEApr5oqyqO9vVaB0wrVZhZpQIPkZhqEZM2YoFAo1/axPnz766U9/amOrnMPn2//lODMz0+aWOAuBEnFXuXO31m+uaX/N5GEEQ2Gt31yjzdW7o7q/FYHSKddmhVSqCYW1qLl1vksuuUS9e/du+vfChQtN360sUTU0NEgSQ94HoYYScbe0xNvm8jmxcrsMPf++V3OK8g97344Eyh07dmjdunX60Y9+pPT09Ba3O+XazJYKNaGwFjW3iaVTp0664YYbNGPGDPXr10+XXnqp3U1yjEgPJYGyOXooEXfFm6otCVzS/p6w4opqS44tSb/73e80duxY9e3bV4888oj8fn+z2xP52tqS7DWhsBY1t4nr2muvVc+ePXXPPfc0fQEHgbItBErE1R5/QF6L/1B4a33tGkJrTw9lMBiUy+XSzp07NXXq1GbB0onXZoZkrgmFtai5TVz1/oC2N7j01t826VvDRlGWcAACZesY8kZcVdXWt+idMFtY0o8mXKMue2ujuv/DDz+s119/Par7VlRUNAXQcDisnTt3asqUKbr55pt1z+LfKyxra4zCkrbW1iu/d3dLzxMRqQk124E1oQNyGN5MRg8XV3a4TCIYCisYCmvG8jLV7PFramGeya1DayhLiA6BsnUESsRVYyB0+DuZIOxyt2uIJtr7tnU/wzAUjFOHf7weQyl5a0JhLWpuEwvbw7ZPJFCybFBzBErEVZonPqHrwfvvi6oXz+Px6Prrr9d1110X1XHnz5+vWbNmNfVSHnPMMZo1a5YmTpyozbV79UD5X2JqdzTi9RhK8akJnaNvAmU4HNYbb7yhRx99VDfddJNGjhxpyblhHatqboed0CMlw4vVlpV6NXtleVNZS3vLEuYW5WtsioV9eihbRw0l4qpfdqasLu02vj6PFdxut0KhkI455hg9+uij+uSTT3TdddcpPT094a/tYPGsCQ0EAnrhhReUn5+vCy64QKtWrdL7779v6blhDWpuEwdLgXUMgbJ19FAirjLTPcrNylCVhUElNztDmenRvbQNw2jXpJwrrrhC/fv314UXXthi2SCnXVus4lXvesu8hVr+1G+0c+fOppICt9stl8ulYDAot9ttcStgFmpuEwdlCR3n8/nkcrlYl/MgBErEXeGgHC0pqbKsLq9wYE7U929voDzmmGMOuR6bk64tVvGq1Xzqmd+pcedOSd/MuA8Gg7rjjjt0xx13NH1wp6WlKT09vem/nfQzj8fDsiqyr+a2oqJC3bp10zHHHGP6eZMRZQmxiezjzXu+OQIl4m7ckFw9u3GrJccOhsIaPzT6b8ntDZSH46Rri1W8ajXHXnqJXnnyAe3du7fZVm9XXnmlzjzzTDU2NqqxsVF+v7/pvw/8X2s/37NnT1T3i/w8GAzGfB12htto7tupU6dmezNbIZ41t+FwWOvXr9eCBQv01ltvady4cXr++ectOXeysbIsYcmkIaYe14kigRLNESgRd3m9umn4gB7asKXW1D8+bpehYf2z2zUkZnagdNK1xSpSE2rlsLch6ZG75+qB2dO1cOFCLVq0SIFAQMFgUGeccYYmTpxo4dm/EQwGtW/fvkOGz/YE2oN/1tZ9vvrqq6iPt2/fvpiv0+PxmBpSD/yZu3OmvHXHmfBstM1b69PuhkateXOV5s+frw8++EBu9/4VHQ78MoK2UZYQOwJl6wiUsMWCMYM1ctFaU0OXx2VowZjBph2vo5Ll2uJZE5qZfpR+9atf6YYbbtC8efO0ePFi9enTx7LzHsztdsvtdqtz585xO2d7hcPhQ4beaENwe3/m8/miOqeR1UdH/XihtY+BpOO+dYq+qvqw6WfBYFCGYej//b//pzlz5qhz587q3Lmz0tPTW/3vQ92Wnp6e9OULLAUWOwJl6wiUsEWfrAzNLcrXjOXmzdycV5Tf7vods3soJedcmxniXRMamT3/m9/8Rh4PH08HMgyjqUfQif7h/UJjHt1g+XlcnpbXHw6HVVVVpcWLF2vv3r3y+/3au3evAoH27+7icrmiCp7RBtSO3K9Tp06Whdp4LwWWjBoaGgiUreATG7YZW5Crmj3+2GYahsOSYeiW0YM6NMPQikApmXRtX+votZnBrprQTp06WXJOWCdeNbdri99R6eoVuuOOO1RdXa1wOCyPx6OJEyfqgQceaHbfYDDYFC4PDJqt/bsj96utrW12vwNvj/x/Y2Njh67TivCqTp3lrbM2CEWWAovXahR2oIeydcn7jCMhTC3MU4+u6U0L67brm3M4JCMc0q8vPqXDgcuqQCnFdm1ulyGPy9C8onxbl+JIpppQWCteNbcn5ByhkyZN0k9+8hM99NBDuuuuu7R79+4Wy3hJ+0sZMjIybP3jHwqF5Pf7ow6p7Qm0e/fu1ZdffnnY+/r9fklSp5zj1fuqhyy93nhvD2sHAmXrCJSw3diCXJ1+Qo/Dbv0VEbm9m2+7ennf1WUFF3b43FYGSqnj1zasf7ZjtjVLlppQWCve67B26dJFt956q6655ho9/vjjOv/88y07byxcLpe6dOli6zZ9oVBIjY2NKv2kRhOe+5fl54vn9rB2IFC2jkAJR+iTlaElk4aocuduLS3xqriiWt5aX7PeDkP7/6AUDszR+KG5uu36K9XQ2GBXk6PWkWtzUs9dMtWEwlp2rMN61FFHacaMGaafL5lE6kKzusfncyWe28PawefzKSsry+5mOA6BEo6S16ub5hTla47yVe8PaPL0X+hfZeVa9sLz6pedaXpdjtU9lAc6+Nq21tarMRBSmsdlybWZKVlqQmGtZFqHNRnFqywhXtvD2oUeytY59y8YUlZtba0efPBB+f1+ffje26r+7DM99+ACSdLll1+u/HzzZhDGM1AeKDPdk3A1RslQEwprUXPrbMm2PaxdCJStS+5nHQnpP//5j+68886mXT3C4bDuv/9+BQIBHXPMMUkRKBNVMtSEwlrU3DpbMm0PaxcCZeuSu9ABCamgoECnnXZa0+4X4XBYgUBAXbt21ZVXXmn6+QiU7ROpCX37pjM1YUhf9c3O0MEr5hmS+mZnaMKQvloz7UwtmTSEMJkiIjW3ZqLm1jzjhuRaug5lKpQlEChbRw8lHMcwDN11110aPXp0089cLpemT5+uI4880vRzoWMSuSYU1qLm1rkoS4gdgbJ19FDCkUaOHNnUSylJGRkZuvHGG00/D0Pe5ojUhJ6Se5Tye3cnTEJTC/P064sGK93jktvVvi9ubpehdI9Ld180WFMKB1jUwtS1YMxgedr5nBxOqpQlhMNhAmUbCJRwpEgvZSTsWdE7GTkPgRKwxtiCXK2ZNkLD+mdL0mGDZeT2Yf2ztWbaCHomLUJZQsft27dPwWCQQNkKuhHgWCNHjlSvXr303//+15LeSYlACVgt0ddhTVaUJXRMQ8P+tY8JlC0RKOFYvsagHnlhpbZu+1Sf+Qx16mLN/rAESsB61Nw6D0uBtZ/Pt3/JJQJlS7yD4ShNvRibquWti/RipOs3H/9lfy9GVoYKB+Vo3BBzPsDooQTiLxHXYU1WLAXWPgTKthEo4Qjb6nyH/UALS6qq82lJSZWe3bhV3Y4drV7ed2M6L7O8AaQ6yhKiR6BsG4EStltW6m0acpF02GGXyO27M3prz6CfaFmpV2M7OORCDyUA7EdZwuERKNvGqwO2eri4suNF4YZLYRmasbxMNXv8mlqY1/5DECgBoAXKEloXCZRdunSxuSXOw7JBsM2yUm/sMwy/HrK+d3WFXiz1dugQBEoAQDTooWwbgRK22Fbn0+yV5aYec9bKcm2r87Xrd+ihBABEi0DZNgIlbDFzRVlTzaRZAqGwZq4oa9fvMCkHABAtAmXbCJSIu8qdu7V+c42p+8hK+yfrrN9co83Vu6P+HXooAQDR8vl88ng86tSpk91NcRwCJeJuaYm33Xv7RsvtMvT8+9HXUhIoAQDRYh/vthEoEXfFm6pN752MCIbCKq6obtfvECgBANEgULaNQIm42uMPyNvOiTPt5a31qd4fiOq+9FACAKJFoGwbgRJxVVVbL6vjW1jS1tr6qO7LpBwAQLQaGhoIlG0gUCKuGgMhR52HHkoAQLTooWwbgRJxleaJz0su2vMQKAEA0SJQto1Aibjql50pqweZja/PEy0CJQAgGgTKthEoEVeZ6R7lZln7ZszNzlBmenTb1NNDCQCIFoGybQRKxF3hoBxL16EsHJgT9f2ZlAMAiJbP51OXLl3sboYjESgRd+OG5Fq6DuX4oblR358eSgBAtOihbBuBEnGX16ubhg/oYXovpdtlaPiAHhqQ0y3q3yFQAgCiRaBsG4EStlgwZrA8JgdKj8vQgjGD2/17BEoAQDQIlG0jUMIWfbIyNLco39RjzivKV592TvihhxIAEC0CZdsIlLDN2IJcTR89MLaDfB0Gbxk9SJcVRF87GcGkHABAtAiUbSNQwlZTC/P064sGK93jan9NZTgkIxzU3RcN1pTCAR06Pz2UAIBohMNhAuUhEChhu7EFuVozbYSG9c+WpMMGy8jt3XzbdcKmFzrUMxlBoAQARKOxsVHhcJhA2QYCJRyhT1aGlkwaordvOlMThvRV3+yMFjvqGJL6ZmdowpC+WjPtTA38bLXSGnfHfG4CJQDgcHw+nyQRKNsQ3XYiQJzk9eqmOUX5mqN81fsD2lpbr8ZASGkel/plZ0a9A0606KEEAESDQHloBEo4Vma6R/m9u1t6DiblAACiQaA8NIa8kdLooQQARINAeWgESqQ0AiUAIBqRQMle3q0jUCLlESgBAIdS7w/o4517lHbMQG33uVTvD9jdJMehhhIpjR5KAEBrKnfu1tISr4o3Vctb51NY0jFX3K9rlm+RsXyLcrMyVDgoR+OG5CqvVze7m2s7AiVSGpNyAAAH2lbn08wVZVq/uUZul6FgqGWnQ1hSVZ1PS0qq9OzGrRo+oIcWjBnc7u1/kwlD3khp9FACACKWlXo1ctFabdhSK0mthskDRW7fsKVWIxet1bJSr+VtdCp6KJHyCJQAgIeLK3Xv6ooO/W4wFFYwFNaM5WWq2ePX1MI8k1vnfPRQIqXRQwkAWFbq7XCYPNi9qyv0Ygr2VBIokdIIlACQ2rbV+TR7Zbmpx5y1slzb6nymHtPpCJRIaUzKAYDUNnNFmQKHqZVsr0AorJkrykw9ptMRKJHS6KEEgNRVuXO31m+uOezkm/YKhsJav7lGm6t3m3pcJyNQIuURKAEgNS0t8crtsmakyu0y9Pz7qVNLSaBESqOHEgBSV/GmatN7JyOCobCKK6otObYTESiR0giUAJCa9vgD8lo8ccZb60uZbRoJlEhpTMoBgNRUVVsvq7sTwpK21tZbfBZnIFAipdFDCQCpqTEQSqrz2I1AiZRHoASA1JPmiU8Eitd57JYaVwm0gR5KAEhN/bIzZXXRk/H1eVIBgRIpjUAJAKkpM92j3KwMS8+Rm52hzHSPpedwCgIlUhqTcgAgdRUOyrF0HcrCgTmWHNuJCJRIafRQAkDqGjck19J1KMcPzbXk2E5EoETKI1ACQGrK69VNwwf0ML2X0u0yNHxADw3I6WbqcZ2MQImURg8lAKS2BWMGy2NyoPS4DC0YM9jUYzodgRIpjUAJAKmtT1aG5hblm3rMeUX56mPxhB+nIVAipTEpBwAwtiBX00cPNOVYt4wepMsKUqd2MiI15rIDbaCHEgAgSVML89Sja7pmryxXIBRu12Qdt8uQx2VoXlF+SoZJiR5KgEAJAJC0v6dyzbQRGtY/W5IOO1kncvuw/tlaM21EyoZJiR5KpDh6KAEAB+qTlaElk4aocuduLS3xqriiWt5anw78S2Fo/6LlhQNzNH5obkrN5m4LgRIpjUAJAGhNXq9umlOUrznKV70/oK219WoMhJTmcalfdmbK7IATLR4NpDQm5QAADicz3aP83t3tboajUUOJlEYPJQAAsSNQIuURKAEAiA2BEimNHkoAAGJHoERKI1ACABA7AiVSGpNyAACIHYESKY0eSgAAYkegRMojUAIAEBsCJVIaPZQAAMSOQImURqAEACB2BEqkNCblAAAQOwIlUh49lAAAxIa9vJFQVq9eraKiIgWDQQWDQUlSp06d5HK59PLLL6uoqKhdx2PIGwCA2BEokVD69OmjxsbGZiEwEAhIknJzc9t9PAIlAACxY8gbCeVb3/qWLrvsMnk833wX8ng8uvDCC3XyySe3+3gESgAAYkegRMKZNWtW03C3tL+Hcs6cOR06FpNyAACIHYESCSfSS2kYhgzD6HDvZAQ9lAAAxIZAiYQ0a9YshcNhhcPhDvdOSgx5AwBgBiblICF961vf0tChQ7V3796YeicNw1AoFDKvYQAApCACJRJSvT+gxa++qcZASOXbd6lfdqYy09v3cq73B+TP6Kl9wXCHjwGgpXp/QFtr69UYCCnN4+K9BaQAI8x4HxJE5c7dWlriVfGmannrfDrwhWtIys3KUOGgHI0bkqu8Xt0sOwaAlnhvAamNQAnH21bn08wVZVq/uUZul6FgqO2XbOT24QN6aMGYweqTlWHaMQC0xHsLgESghMMtK/Vq9spyBULhQ/6hOpjbZcjjMjS3KF+SYj7G2IL2L5oOJDsz3p+8t4DkQKCEYz1cXKl7V1fY3QxJ0vTRAzW1MM/uZgCOYdb7k/cWkBxYNgiOtKzU65gwKUn3rq7Qi6Veu5sBOIKZ70/eW0ByIFDCcbbV+TR7ZbndzWhh1spybavz2d0MwFZWvD95bwGJj0AJx5m5okyBdtRjxUsgFNbMFWV2NwOwlRXvT95bQOIjUMJRKnfu1vrNNe0q8I+XYCis9ZtrtLl6t91NAWxh1fuT9xaQ+AiUcJSlJV65XYbdzWiT22Xo+fep90JyeuWVV/TUU0+psbGx1dutfH/y3gISG4ESjlK8qdqRvZMRwVBYxRXVdjcDsMScOXN09dVX6/jjj9cTTzzRIlha+f7kvQUkNgIlHGOPPyBvAhTme2t9qvcH7G4GYJkdO3Zo8uTJzYJlPN6fvLeAxMXmqnCMqtp6Obdv8hthSaeOOEeuXdvtbgpgqi1btkiSIssTb9++XZMnT9aNN96otf/+j+Xvz7CkrbX1yu/d3eIzATAbgRKO0RgI2d2EqA0bPkLZ4a/sbgZgqmeffVa1tbVN/zaM/fWSp556qlyetLi0IZE+BwB8g0AJx0jzJE4FxvRpN9KLgqTz5ptvqra2Vm63W5J01VVXaebMmerXr5/Kt++KSxsS6XMAwDcIlHCMftmZMiTHD3sb2t9WINlkZGTI7XZr4sSJuuOOO9SvX7+m2+Lx/uS9BSQuAiUcIzPdo9ysDFU5fGJObnaGMtN56yD5vPjii3K73crNzW1xWzzen7y3gMTF2AIcpXBQjuPXoSwcmGN3MwBLHH/88a2GyQgr35+8t4DERqCEo4wbkuv4dSjHD237Dy6QzKx8f/LeAhIbgRKOkterm4YP6OHIXkq3y9DwAT00IKeb3U0BbGHV+5P3FpD4CJRwnAVjBsvjwEDpcRlaMGaw3c0AbGXF+5P3FpD4CJRwnD5ZGZpblG93M1qYV5SvPlkZdjcDsJUV70/eW0DiI1DCkcYW5Gr66IF2N6PJLaMH6bIC6rsAydz3J+8tIDkY4cgeW4ADLSv1avbKcgVC4XZNBnC7DHlchuYV5SssxXwM/uABLZnx/uS9BSQHAiUcb1udTzNXlGn95hq5XcYh/3BFbh8+oIcWjBncNIxmxjEAtMR7C4BEoEQCqdy5W0tLvCquqJa31tdsxw5D+xdFLhyYo/FDc9ucLWrGMQC0xHsLSG0ESiSken9AW2vr1RgIKc3jUr/szHbvsGHGMQC0xHsLSD0ESgAAAMSEWd4AAACICYESAAAAMSFQAgAAICYESgAAAMSEQAkAAICYECgBAAAQEwIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJgQKAEAABATAiUAAABiQqAEAABATAiUAAAAiAmBEgAAADEhUAIAACAmBEoAAADEhEAJAACAmBAoAQAAEBMCJQAAAGJCoAQAAEBMCJQAAACICYESAAAAMSFQAgAAICYESgAAAMSEQAkAAICYECgBAAAQEwIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJgQKAEAABATAiUAAABi8v8BRZ0v/RMgHKoAAAAASUVORK5CYII="
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# get node dataset from data service\n",
     "centerville_epn_link = '5b1fdc2db1cf3e336d7cecc9'\n",
@@ -152,7 +96,7 @@
     "# instead of reading it from the graph file\n",
     "g, node_coords = NetworkUtil.create_network_graph_from_link(link_filepath, fromnode_fldname, tonode_fldname, is_directed=True)\n",
     "print(node_coords)\n",
-    "print(g)\n",
+    "print(nx.info(g))\n",
     "nx.draw(g, node_coords)"
    ]
   },
@@ -165,41 +109,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "ExecuteTime": {
-     "start_time": "2023-10-23T14:57:26.735406Z",
-     "end_time": "2023-10-23T14:57:26.887482Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dataset already exists locally. Reading from local cached zip.\n",
-      "Unzipped folder found in the local cache. Reading from it...\n",
-      "Dataset already exists locally. Reading from local cached zip.\n",
-      "Unzipped folder found in the local cache. Reading from it...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/lz/cytsgpz97f34yd69304b9vyc0000gr/T/ipykernel_12874/3196477836.py:18: FionaDeprecationWarning: This function will be removed in version 2.0. Please use CRS.from_epsg() instead.\n",
-      "  NetworkUtil.build_link_by_node(node_filename, graph_filename, id_field, out_filename)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": "True"
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# this process can be done using the local shapefile, \n",
     "# instead of using the dataset from the incore data service.\n",
@@ -230,39 +142,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "ExecuteTime": {
-     "start_time": "2023-10-23T14:57:30.115378Z",
-     "end_time": "2023-10-23T14:57:30.191292Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dataset already exists locally. Reading from local cached zip.\n",
-      "Unzipped folder found in the local cache. Reading from it...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/lz/cytsgpz97f34yd69304b9vyc0000gr/T/ipykernel_12874/1565815967.py:20: FionaDeprecationWarning: This function will be removed in version 2.0. Please use CRS.from_epsg() instead.\n",
-      "  NetworkUtil.build_node_by_link(link_filename, link_id_field, fromnode_field, tonode_field, out_node_filename, out_graph_filename)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": "True"
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# this process can be done using the local shapefile, \n",
     "# instead of using the dataset from the incore data service.\n",
@@ -308,23 +190,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "ExecuteTime": {
-     "start_time": "2023-10-23T14:57:33.444367Z",
-     "end_time": "2023-10-23T14:57:34.943261Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "network dataset is created with id 6536d02dfaa0854c4fb04416\n",
-      "attching files to created dataset\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "dataset_prop = {\n",
     "  \"title\": \"Test epn network\",\n",

--- a/manual_jb/content/notebooks/create_network_dataset/create_network_dataset.ipynb
+++ b/manual_jb/content/notebooks/create_network_dataset/create_network_dataset.ipynb
@@ -17,8 +17,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-23T14:56:54.196461Z",
+     "end_time": "2023-10-23T14:56:55.335895Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import ast, os\n",
@@ -30,9 +35,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-23T14:56:56.525730Z",
+     "end_time": "2023-10-23T14:57:06.236064Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connection successful to IN-CORE services. pyIncore version detected: 1.12.0\n"
+     ]
+    }
+   ],
    "source": [
     "client = IncoreClient()\n",
     "datasvc = DataService(client)"
@@ -47,9 +65,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-23T14:57:10.022062Z",
+     "end_time": "2023-10-23T14:57:10.181272Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset already exists locally. Reading from local cached zip.\n",
+      "Unzipped folder found in the local cache. Reading from it...\n",
+      "network_graph.csv successfully created.\n"
+     ]
+    }
+   ],
    "source": [
     "# get link dataset from data service\n",
     "centerville_epn_link = '5b1fdc2db1cf3e336d7cecc9'\n",
@@ -80,11 +113,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "ExecuteTime": {
+     "start_time": "2023-10-23T14:57:15.586709Z",
+     "end_time": "2023-10-23T14:57:15.782454Z"
+    }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset already exists locally. Reading from local cached zip.\n",
+      "Unzipped folder found in the local cache. Reading from it...\n",
+      "{0: (-97.4745, 35.266), 1: (-97.4745, 35.2626), 2: (-97.4873, 35.2626), 3: (-97.4873, 35.196), 4: (-97.4836, 35.196), 5: (-97.4369, 35.196), 6: (-97.4838, 35.2509), 7: (-97.5113, 35.2509), 8: (-97.5023, 35.246), 9: (-97.4903, 35.2567), 10: (-97.4964, 35.2604), 11: (-97.49950726683866, 35.2427), 12: (-97.4691, 35.2427), 13: (-97.47226381921406, 35.246689303630674), 14: (-97.48874482954297, 35.23152065345497), 15: (-97.4888, 35.2165), 16: (-97.4768, 35.2165), 17: (-97.4888, 35.2101), 18: (-97.4601, 35.2509), 19: (-97.46507448011698, 35.25914896023397), 20: (-97.4442, 35.259), 21: (-97.4466, 35.2406), 22: (-97.4466, 35.2305), 23: (-97.4691, 35.2312), 24: (-97.3976, 35.2045), 25: (-97.3964, 35.2311), 26: (-97.40211901205474, 35.23360380241095), 27: (-97.4021, 35.2561), 28: (-97.4112, 35.2398), 29: (-97.41233569457059, 35.21449438614856), 30: (-97.43521617501703, 35.215086558444916), 31: (-97.4656664519788, 35.21571961356189)}\n",
+      "DiGraph with 32 nodes and 30 edges\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": "<Figure size 640x480 with 1 Axes>",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAApQAAAHzCAYAAACe1o1DAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAABfEklEQVR4nO3de3hU1d328XvPDAkkIJpAUJSASOCpKT5qG6EoYiqgVRuL+igtoCIqWqiKRUVsOSm04gGt1iMeKmLxBBaLVURToIJpak95o5JQJIOCpEkUIRMmzOH9AycSksAks/fsPTPfz3X1qmQme689p9yz1m+tZYTD4bAAAACADnLZ3QAAAAAkNgIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJgQKAEAABATAiUAAABiQqAEAABATAiUAAAAiAmBEgAAADEhUAIAACAmBEoAAADEhEAJAACAmBAoAQAAEBMCJQAAAGJCoAQAAEBMCJQAAACICYESAAAAMSFQAgAAICYESgAAAMSEQAkAAICYECgBAAAQEwIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJgQKAEAABATAiUAAABiQqAEAABATAiUAAAAiAmBEgAAADEhUAIAACAmBEoAAADEhEAJAACAmBAoAQAAEBMCJQAAAGJCoAQAAEBMCJQAAACICYESAAAAMSFQAgAAICYESgAAAMSEQAkAAICYECgBAAAQEwIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJh47G4AgEOr9we0tbZejYGQ0jwu9cvOVGY6b10AgHPwVwlwoMqdu7W0xKviTdXy1vkUPuA2Q1JuVoYKB+Vo3JBc5fXqZlczAQCQJBnhcDh8+LsBiIdtdT7NXFGm9Ztr5HYZCobafntGbh8+oIcWjBmsPlkZcWwpAADfIFACDrGs1KvZK8sVCIUPGSQP5nYZ8rgMzS3K19iCXAtbCABA6wiUgAM8XFype1dXxHyc6aMHamphngktAgAgeszyBmy2rNRrSpiUpHtXV+jFUq8pxwIAIFoESsBG2+p8mr2y3NRjzlpZrm11PlOPCQDAoRAoARvNXFGmQDvqJaMRCIU1c0WZqccEAOBQCJSATSp37tb6zTXtmoATjWAorPWba7S5erepxwUAoC0ESsAmS0u8crsMS47tdhl6/n1qKQEA8UGgBGxSvKna9N7JiGAorOKKakuODQDAwQiUgA32+APyWjxxxlvrU70/YOk5AACQCJSALapq62X1ArBhSVtr6y0+CwAABErAFo2BUFKdBwCQ2giUgA3SPPF568XrPACA1MZfG8AG/bIzZc387m8YX58HAACrESgBG2Sme5SblWHpOXKzM5SZ7rH0HAAASARKwDaFg3IsXYeycGCOJccGAOBgBEokpHp/QOXbd+kf3i9Uvn1XQi6PM25IrqXrUI4fmmvJsQEAOBjjYUgYlTt3a2mJV8WbquWt8zVbdseQlJuVocJBORo3JFd5vbrZ1cyo5fXqpuEDemjDllpTg6XbZWhY/2wNyHH+YwAASA5GOBy2ejk8ICbb6nyauaJM6zfXyO0yDhm+IrcPH9BDC8YMVh+L6xRjta3Op5GL1spv4vI+6R6X1kwb4fhrBwAkD4a84WjLSr0auWitNmyplaTD9uRFbt+wpVYjF63VslJn72fdJytDc4vyTT3mvKJ8wiQAIK4IlHCsh4srNWN5mfyBULuHhIOhsPyBkGYsL9PDxZUWtdAcYwtydcaAbFOOdcaAHrqsgNpJAEB8ESjhSMtKvbp3dYUpx7p3dYVedHBP5bJSr/6yudaUY/1lc42jrxUAkJwIlHCcbXU+zV5ZbuoxZ60s17Y6n6nHNEMqXSsAIHkRKOE4M1eUKWDycjqBUFgzV5SZekwzpNK1AgCSF4ESjlK5c7fWb64xfX3GYCis9ZtrtLl6t6nHjUUqXSsAILkRKOEoS0u8lu4e8/z7LesLw+Gw1qxZo7ffftuS87bFjmsFAMAKBEo4SvGmakt3jymuqG76dzgc1ttvv62hQ4dq1KhRuu666yw5b1viea0AAFiJQAnH2OMPyGvxZBJvrU979u5rCpKjR4/WBx98IEkKBoOWnvtA8brWRNySEgCQeNh6Ec3U+wPaWluvxkBIaR6X+mVnKjM9Pi+Tqtp6Wb1tU1hS3qnD9PlHf2v6WSRI7ty5U2effbbFLdjPn9FT4W9PsPQcYUlba+uV37u7pecBAIBACcfskd1o4vaDh9Kt+1H6XJJhGDpw51GXy6WcnJy4tGF3WrY+jcN54vWYAgBSG4EyhUWzR3ZYUlWdT0tKqvTsxq2W7pGd5olPBcaKV19W484tmjNnjlauXCmPx6NAIKCePXvq97//fVzaUL59l85/6C+WnydejykAILXx1yZFOXGP7H7ZmbJmzvM3jK/Pc8opp+gPf/iD/v73v+u8886TJKWnp1t89m/E81oBALAaPZQp6OHiyg5vaxgMhRUMhTVjeZlq9vg1tTDPtHZlpnuUm5WhKgsnq+RmZzSrCY0Ey3/9619qbGy07LwHs+NaAQCwCj2UKcbpe2QXDsqxdG3GwoGt10j+7//+rwoKCiw5b1vsulYAAMxGoEwhibBv9LghuZauzTh+aK4lx+6IZLzWen9A5dt36R/eL1S+fRfLFgFAimA8LIVYuW/0kklDTDleXq9uGj6ghzZsqTU1bLldhob1z9aAHOtmqbdXslyrU1YJgL3LfgFIbUb4wHVTkLQqd+7WqAfWWXb8NdPONC3AbKvzaeSitfKbuORNuselNdNGWDI7PRaJfK3RrBIQEbndylUCUhWBHoATMOSdIhJp3+g+WRmaW5Rv2vEkaV5RviNDTKJeqxNXCUg12+p8mvBUiUY9sE5LSqpUdVCYlJov+zXqgXWa8FSJqSUqABBBoEwRibZv9NiCXE0fPdCUY90yepAuK3BO7eTBEu1aHy6u1IzlZfIHQu1+TQVDYfkDIc1YXqaHiystamHyI9ADcBoCZQpI1H2jpxbm6dcXDVa6x9Xu3lW3y1C6x6W7LxqsKYUDTG2XFRLlWp2+SkAqINADcCICZQqI1x7ZW2vrTT/u2IJcrZk2QsP6Z0vSYcNW5PZh/bO1ZtoIR/dMHszp15oIqwQkOwI9AKdiUk4K+If3C415dIPl51lx/TCdknuUZcdvmnxQUS1vbSuTD7IzVDgwR+OH5jpqNndHOPFaJzxVYtmMdLNWCUhmiTyBC0DyI1CmgHjtG73qZ2cov3d3y88j7V8e5ZKJ16uhMaDf/uaBpF4exQlLwSTSKgHJikAPwMkY8k4BybhvdGa6Rxn+OmX4diq/d/ekDZPS/mvN791dp+QeZdu1JtIqAcmocudurd9cY/rEumAorPWba7S5erepxwWQegiUKSCyb7SV2Dc6uSXaKgGJxufzac2aNQoEWp/YRqAH4HQEyhTBvtHoqERdJSCRvPrqqxo1apQGDRqkF154QcFgsNntBHoATkegTBHJuG804iNeqwT85V+b9Mknn6iqqkrbtm3TZ599ps8//1zV1dWqqalRXV2dvvzyS3311Vfas2ePfD6f/H6/9u3bp2AwqEQuB29oaJAkffLJJxo3bpxOPPFEvfzyywqFQgR6AAmBMcoUYeW+0QW5R+iEnl1NOyacpdHEWcWHUvSji9S4I/YlcVwul1wul9xud9N/t/a/Q90ey+925BgVFfuvOxKKKyoqdOmllyorK0u/emxJ3Jb9itekOgDJh0CZQhaMGayRi9aaGijDwYBeve0SZdy0S/n5+crPz9egQYM0aNAgFRQUKDf30D2XTpjBjENL88RnIOOJRx/RcV2lUCjU7H/BYLDFzzpyHzOO1dZth/qdQCBw2ONt37691cekrq5O5R9tkmTOTkqHEq8vDgCSE3+5U0hk3+gZy8tMO+aNpx+jm+/5r/aGQvrggw/0z3/+U5IUDAZ15JFH6osvvmjxO01rLG6qlreulTUWszJUOChH44bkKq8XS8nYLbJKgJW9ZIakS84dkbJfJh566CHdeOONCofDcrvdcrvduu6663TrrbfqS6Or/hCHZb/i9cUBQHJKzU/vFDa2IFc1e/ym7LZxy+hBmlI4QJ/efLPuu+8+hcPhpskEhmFoypQpze6/rc6nmSvKtH5zjdwuo9We0rCkqjqflpRU6dmNWzV8QA8tGDOYhZdtFFkloMrCOr5UXyUgHA4rHA6rc+fOmjJliqZPn66jjz5aknSkPxCXQB/PZb8AJB++kqYgs/eNvv3229W1a/Mayp49e2rGjBlN/15W6tXIRWu1YUutJB122D1y+4YttRq5aK2WsUWcrVglwFoXXXSRFi1aJK/Xq3vvvbcpTEos+wW0V70/oPLtu/QP7xcq376LCWdxwidIihpbkKvTT+hx2B7DiMjtw/pnt+gxzMrK0syZMzVz5kyFw2F5PB7V1dXpjDPO0NKlS1VcndbhHtFgKKxgKKwZy8tUs8evqYV5HToOYjNuSK6e3bjVkmOzSoB03HHH6aabbmrz9sJBOVpSUmXJSg0EeiQDSqnsx9aLMGXfaJ/Pp+OPP17V1dV64oknVFBQoHHjxqnuqP9R+vCrTGvr3RcN1mUF+8PHxRdfrIaGBr3xxhumHR9tY+s/+7D1JdC6aEqpIiK3U0plDQIlmoll1vWbb76pdevWaf78+TIMQ5Xb63T+IxvVGDz870Yr3ePSmmkj1Ccrg0AZZ9vqfBq5aK38Js4GPvD5xKER6IHmlpV6NXtluQJfj2RFy+0y5HEZmluUr7EFqT06YiZqKNFMLPtGn3vuuVqwYIEMY3+t3bw/VSoYNrfuLhAKa+YK82apI3qRVQLMNK8onzAZpQVjBstjch2rx2VowZjBph4TiIeHiys1Y3mZ/IFQu79kBUNh+QMhzVhepoeLKy1qYeohUMISlTt3a/3mGtNrvoKhsNZvrtHm6t2mHhfRGVuQq+mjzVkT8ZbRg5rKF3B4BHpgv2WlXlNWKpGke1dX6EUmfZqCQAlLLC3xWjor+Pn3+QCwi9mrBCB6BHqkum11Ps1eWW7qMWetLNc2i7c3TQUESliieFO1pXuHF1dUW3JsRGdsQa7WTBuhYf2zJemwwTJy+ynHZOjtm84kyMSAQI9UNnNFmQIm/22hlMocLBsE0+3xB+S1+Nuet9anowxevnbqk5WhJZOGRL1KwDkDMjQsv7+qfvddvfXWW8rKyrKr6QnPzGW/gEQRKaUy24GlVKx20HHM8obpyrfv0vlx2CruW1WvyfjyM2Z5O8ihVgn49NNP1adPH0lSr1699PLLL2v48OF2NjcpmLHsF5AI5qwst3Q91glD+mqOyXXKqYQuHpiu0cRlZQ4lbLhlTZUmOiqySkBrPJ5vPm6qq6s1YsQIzZ49W3fccUez29A+eb26aU5RvuYoP6ZlvwCni0cp1RwRKDuKGkqYLs0Tn5eVETZxgUtYzu12N/13ZO/quXPnasSIEfL5KIg3QyzLfgFOFq9SKrZp7DgCJUzXLzvT8p5DQ1J641cWnwVmaq0X0jAM/b//9/9UU2N+XRSA5FFVWy+r6/PCkrbW1lt8luRFoITpMtM9yrW46D83O0PuMN8kE8mBgTKy+P0tt9yiqqoq5eYy6xtA2+JVShWv8yQjAiUsUTgox9J1KAsH5lhybFinU6dOcrlcSktL01VXXSWPx6OsrCwdeeSRdjcNgMPFq5QqXudJRjxysMS4IbmWFk+PH0qPVqLp3Lmz1qxZo08++USLFy/WNddco7vvvlu7du2yu2kAHC5epVT9sjMtPkvyIlDCEnm9umn4gB6m91K6XYaGD+jB8icJqrCwUL1795Yk3XHHHfL5fFq0aJHNrQLgdPEqpWIiW8cRKGGZBWMGy2NyoPS4DC0YM9jUY8Iexx57rH7605/q/vvvV21trd3NAeBwlFI5G4ESljm6Wyed23O3qcecV5TPLh9J5LbbblMoFNLChQvtbgoAh6OUytkIlDBVOBzWxo0bNWXKFB111FH6zY2XKa/hY1OOfcvoQewBnWRycnJ000036aGHHtKOHTvsbg4AB6OUytkIlDDFp59+ql/84hfq27evhg0bpscee0z19fvX83rw2h/o1xcNVrrH1e4PArfLULrHpbsvGqwphQOsaDpsNn36dKWnp+tXv/qV3U0B4HCUUjkXgRKmmDlzpubPn69t27ZJkkKh/Wt5nXDCCTrxxBM1tiBXa6aN0LD+2ZJ02GAZuX1Y/2ytmTaCnskkduSRR2r69Ol6/PHH5fV67W4OAAfrk5WhuSbvt00plTkIlDDFggUL1L9/f7lc37ykPB6P/u///q/p332yMrRk0hC9fdOZmjCkr/pmZ7RYBsKQ1Dc7QxOG9NWaaWdqyaQhvNFTwI033qgjjjhCd955p91NAeBwYwtyNX30QFOORSmVeYxwOGz1bkZIEa+//rouvPBCHfiSev/99zVkyJA2f6feH9DW2no1BkJK87jULzsz6mUbLr74YjU0NOiNN96Iue2w3/33369bb71VH330kfLy8uxuDgCHW1bq1eyV5QqEwu2arON2GfK4DM0ryidMmohACVP87W9/09lnn638/Hzt2rVLH374oXr27KnPP/+8Wa+lmQiUyaWhoUEDBgzQWWedpaVLl9rdHAAJYFudTzNXlGn95hq5XcYhg2Xk9uEDemjBmMGMfpmMFTwRs3//+98aPXq0TjzxRL311lsKBAK65JJLNGLECMvCJJJPly5d9Mtf/lI//elPdfvtt+vb3/623U0C4HCRUqrKnbu1tMSr4opqeWt9OjBWGtq/aHnhwByNH5rLbG6L0EOJmHz88cc688wzddxxx+ndd9+N677M9FAmn8bGRg0aNEinnHKKli9fbndzACSgen9Aw865UB9XbNbbb/1J3xmYyw44cUD3ETrsP//5j84++2z16tVLq1evjmuYRHJKS0vTnDlztGLFCn3wwQd2NwdAAvqsaov+vfYNNe6o0IqnHyJMxknK91DGMikklXm9Xg0fPlydO3fW2rVrdfTRR8e9DbH0UPK8O1cgENC3v/1tHX/88frTn/7U9HOeMwDRmDBhgl544QWFQiGlpaWpqqrKlr9RqSYlP42bai02Vctb10qtRVaGCgflaNyQXOX1otbiYNu3b9f3v/99ud1uvfPOOwnzRuV5Twwej0fz5s3TZZddphXvvq9/7enGcwYgKhUVFVq6dGnTaiPBYFALFy7U/fffb3PLkl9K9VAyGyx21dXVGjFihPbs2aP169erX79+trUl2h5KnvfEU1WzRz++f6W2h7vznAGI2oQJE7Rs2TIFAoGmn6Wnp2vr1q0J0/mRqFKmhnJZqVcjF63Vhi21knTYNasit2/YUquRi9ZqWSk7eNTV1WnUqFH68ssv9e6779oaJqPF8554lpV6NfrB9dppHCmJ5wxAdD777DO98MILCgaDTSuMuN1u+f1+/fa3v7W5dckvJYa8Hy6u1L2rKzr0u8GvF0ydsbxMNXv8mlqYmgsu79q1S+ecc462b9+uP//5zwmx8DTPe+LhOQPQUd26ddPUqVO1e/du/fOf/9THH3+ssWPHKhwOa8SIEXY3L+kl/ZD3slKvZiwvM+14d180OOVW1t+zZ4/OOeccffjhh3r33Xd1yimn2N0kSYce8uZ5Tzw8ZwDMcuedd+qRRx7Rjh077G5KykjqIe9tdT7NXllu6jFnrSzXtjqfqcd0soaGBhUVFamsrExvvvmmY8LkofC8Jx6eMwBIbEkdKGeuKFOgHft7RiMQCmvmCvN6UZzM7/froosuUklJiVatWnXIPbmdhOc98fCcAUBiS9pAWblzt9ZvrmnXhvHRCIbCWr+5Rpurd5t6XKfZt2+fxo4dq+LiYv3hD3/Q8OHD7W5SVHjeEw/PGQCzJXk1nyMlbaBcWuKV22VYcmy3y9Dz7zefSRoOh/Xaa6/p/PPPV3m5uUN38RYMBnX55Zdr1apVevXVVzVy5Ei7mxS1eD/vOLyXXnpJY8eObXPnG54zAFYwDGs+V9C6pA2UxZuqTe/xiAiGwiquqJb0TZA86aSTNGbMGL3xxhv629/+Zsl54yEUCunqq6/Wyy+/rGXLlun888+3u0ntEq/nHdF7++239eKLL+q73/2uLrjgghbBkucMABJfUi4btMcfkNfiYnxvrU/PvfCi7p4/Tx9++GHTmlfS/tpDny/xJgOEw2FNmzZNv/vd7/TUU0/p3HPPdfR1BAIBBYPBpjbWx+l5/++XXykzLSnfOpYIBALyeDwKBAJ68803tWrVKp177rmaNWuWBp9aEJfnrN4fYJtGALBQUi4bVL59l85/6C+Wn2f70z/TvupPLD8PotMp53j1vuohy8/D826eRc+8rAc2dbH8PKt+dobye3e3/DwAnGHevHl67LHHtH37drubkjKS8it7YyAUl/Oc+t3T9Nc/bZVhGAqFvjnnddddpzPPPDMubTDLSy+9pNdee01XXnmlRo8ebXdzorJo0SI1NjbqtttukyR5fW49utn689654NfKzQhaf6Ik8eSTT2rt2rVN7xHDMJSWlqYLL7xQQ08/Q9rUem2lmeL1mQAAqSopA2WaJz6loU89+bjSfXfprrvu0pIlS2QYhoLBoIYOHaof//jHcWmDGebPn6/XXntN99xzj6ZPn253c6L2yiuvqKGhoemxLt++S4/GoWf6gh+cQ29XO7z77rv685//LJfLpS5duujnP/+5brrpJh111FEq374rLm2I12cCAGdIwsFXx0vKT9l+2Zmyem6X8fV5BgwYoGeffVabNm3S+PHj5Xa7lZOTY/HZzXP//ffrF7/4hebNm5dQYbI18XzeEb2cnBxlZmbqF7/4hbZt26a5c+fqqKOOksRzBsA6zPKOr6QMlJnpHuVmZVh6jtzsjGZF/pFguWfPHp177rmWntssjzzyiH7+85/r9ttv1y9+8Qu7mxMzO553HN68efNUW1vbLEhG8JwBQHJIykApSYWDcixd265wYOu9kJ07d06Ib0XPPPOMpkyZohtvvFHz589PiDZHw67nHW1zu91KS0tr83aeMwBIfEkbKMcNybV0bbvxQ3MtOXY8/P73v9ekSZM0efJkLVq0KGnCpMTznoh4zgAg8SVtoMzr1U3DB/QwvecjHAyox77/qmd6Ys4aXbFihSZMmKAJEybokUceSaowKVn3vLtdhoYP6KEBOd1MPS54zgCYj0k58Ze0gVKSFowZLI+Jf6TC4bDchlT5wjx961vf0vLly007djy88cYbuuyyy3TxxRfrqaeearYYezIx+3mXJI/L0IIxg009Jr5hyXtVYZ4zIIUlW4eJ0yVnovhan6wMzS3KN+14hmHov2/+Vv933vd16qmn6uKLL9aYMWP06aefmnYOq7zzzju66KKLdN555+n555+Xx5O8kxTMft4laV5RvvpYPHkklVnxXq19+zGV/3WdaccEALQtqQOlJI0tyNX00QNNOdaXa5/Tj07qpWeffVZ79+7V008/rffff18nnniifvvb3yoYdOZi13/5y19UVFSks846Sy+++KI6depkd5MsZ+bzfsvoQbqswPl1ePX+gMq379I/vF+ofPsu1fsDdjepXcx8zm4sPF6nH23oggsu0LPPPmvKMQEAbUvebqoDTC3MU4+u6Zq9slyBULhdEwDcLkMel6E5PzxRxbXdtXjxYt16661avHixtmzZoldeeUVLlizR1KlT9fzzz+uJJ57Q4MHOGWb761//qvPOO0+nnXaali9frvT0dLubFDdmPO/zivIdHSYrd+7W0hKvijdVy1vn04FXaEjKzcpQ4aAcjRuSq7xezq8lNPM5+9n3l2vKlCmaOHGitm3bpl/84hcMgQGARZK+hzJibEGu1kwboWH9syXpsBMAIrcP65+tNdNG6Men9dVjjz2mq6++WgsXLtTtt9+uI444Quecc45GjRqldevW6csvv9Spp56qO+64Qw0NDZZf0+H885//1DnnnKNvf/vbev3115WRkXpDtrE+704Nk9vqfJrwVIlGPbBOS0qqVHVQmJSksKSqOp+WlFRp1APrNOGpEm2r89nR3HYx6znzeDx67LHHdOedd2rWrFmaPHmyAoHE6rUF0DFMyok/I5yCj3pTr05Ftby1rfTqZGeocGCOxg/NbTFDNBQK6brrrtPixYv12GOP6Z133tFLL72kX/7yl7r99tu1cOFCzZ8/X/369dPjjz+uwsLCpt/1+XwqLy9XQUGB5df44YcfasSIEerbt6/eeecdde+efFsFXnzxxWpoaNAbb7wR1f1jed6dZFmpN6YevLlF+Rrr0KB8MLOes2eeeUbXXHONfvCDH2jZsmXKzGTnHCCZzZ49W08//bS2bdtmd1NSRkoGygPV+wPaWluvxkBIaR6X+mVnHnZXjQND5dNPP60dO3bojjvu0A9/+EMtWbJEn332ma699lr95S9/0cSJE3XPPfcoOztbP/7xj7Vs2TJt3LhRQ4cOtayNlZWVOvPMM9WzZ08VFxcrOzs76nMlkvYGygPV+wM68bQR+vy/NfrTqtc15MT+CbGbysPFlbp3dUXMx5k+eqCmFuaZ0KL46ch79UBvvvmmLrnkkqYe+549e1rYWgB2IlDGn/P/glosM92j/N7t671zuVx67LHHJElXXXWVnnnmGb3++uv6yU9+oqFDh+q1117T2rVrm+ot//jHP+qqq67SsmXLZBiGJk+erL///e9yu91tnqOjtXFbt27V2WefrSOPPFJr1qxJ2jAZq3+Uvi/vvzdIkl5+YpG+/+ijNrfo8JaVek0Jk5J07+oK9eya7tgh/dZ05L16oHPPPVdr167Veeedp2HDhunNN9/UCSecYGILASB1pUwNpdkiofLqq6/WxIkTVVNTo7/+9a8KhUI67bTTtHr1al177bX66KOPdPrpp+vuu++WtL+u49///rcef/zxVo8bS23cZ599prPPPludOnXSmjVrlJPDlnNtmTVrVtMEjcWLF8vr9drcokPbVufT7JXlph5z1sryhKipNNN3vvMdbdy4UYZh6Hvf+55KS0vtbhIAJAUCZQwODpXvv/++SkpKdMYZZ+i8887TwoULdfTRR6t///4tZpfedtttqq6ubvazZaVejVy0Vhu21ErSYevjIrdv2FKrkYv+rBFXzdS+ffv07rvv6thjjzXxSpPLhg0bVFxc3FS0HQ6HNX/+fJtbdWgzV5QpYPL2hIFQWDNXlJl6zETQv39/bdiwQSeccILOOuusDpVMAHC2FK/mswWBMkYHh8rXXntNf/jDH3T77bfrtttu0w9/+EPdf//9LV7ce/bs0dVXX93074eLKzVjeZn8gVC79zUOhsLyB8IKnHqpJt3/svr27WvKtSWrWbNmNSs3CAaDevrpp1VVVWVjq9pWuXO31m+uMX2/62AorPWba7S5erepx00EPXr00DvvvKORI0eqqKhITz/9tN1NAmAylgmLLwKlCQ4Olc8//7zmz5+vl156Se+++666deumfv36qWvXrs1+7/XXX9d//vMfU2vjnvmgRi+WOnv41k4VFRV65513FA6Hm7aedLvdCgQCTXWxTrO0xGv6PtcRbpeh599PzddLRkaGXn31VV1zzTWaNGmS5s6dS68GAHRQyk/KMcuBE3UmTpwoSbriiis0cOBA/ehHP9KePXv0xz/+UQUFBdqxY4e8Xq8+/vhjdTryaM1+1tzt4WatLNewE3qwVWArjjvuON13332qr6/Xu+++q7///e+67bbbZBiGioqK7G5eq4o3VZveOxkRDIVVXFGtOTJ3q8pE4fF49Mgjj6hPnz6644479Omnn+rRRx9N6q1JAcAKfGqaqK1QWVpaqksvvVQjR47Ugw8+qOuvv14nnHCCCgsLNeGpEstq45ZMGmLqcZNBRkaGbr75ZklSIBBQZWWlZs6caXOr2rbHH5DX4okz3lqf6v2BhFg2yQqGYWjmzJk69thjdfXVV2vHjh168cUXWasSANqBIW+THTz8/bvf/U49evTQW2+9pZ/+9KeaMmWKrr32Wvn9fmrjbGYYhuOHOKtq61vM8jdbWNLW2nqLz+J8V1xxhVatWqW1a9eqsLCwxaQ5AInD6Z/tyYhAaYHWQmWnTp304IMP6umnn9Zzzz2n73//+3qi+CNq42yUCAXbjYFQUp3H6UaPHq21a9fK6/Vq2LBh2rx5s91NAtBBifAZn0wIlBaJhMpJkyY1hUpp/1D42rVr9cknn+il9eWW18bh0Jz+LTbNE5+3aLzOkwhOPfVUbdy4UW63W8OGDdNf//pXu5sEAI7HXxELuVwuPf744y1C5dChQ7V2Q4mMbtZu/RapjUPrEmHIu192pqz+jm18fR584/jjj9d7772nAQMGqLCwUKtWrbK7SQDgaARKi7UVKhvTjpAs7o6nNu7QEiFQZqZ7lGvxbP3c7IyUnZBzKJG1KkePHq0LL7xQixcvtrtJAOBY/BWJg0iolL6Z/X1SYXyWqKE2rm2JECglqXBQjpaUVFlSHuF2GSocyBadbenSpYteeeUV3XDDDbrmmmv06aefavbs2dRmAcBBCJRxcnCoXPDoc5KOsvy81Ma1LVFCwbghuXp241ZLjh0MhTV+aK4lx04WbrdbDz/8sI477jjNnDlT27Zt02OPPaZOnTrZ3TQAbUiEzoJkQ6CMowND5R03XKs+N78kWVghR23c4SXCh05er24aPqCHNmypNbWX0u0yNKx/tgbkdDPtmMnKMAzdfvvtOvbYYzVp0iTt2LFDL730UovdrwA4R6J0GiQLuq/iLBIqr7p8nPZ98bml56I27tASZchbkhaMGSyPyUtMeVyGFowZbOoxk93ll1+uVatWaf369axVCQAHIFDaIBIq+3f2KRwKWnIOauMOL5ECZZ+sDM0tMnd7xHlF+WzP2QGjR4/WunXr9Omnn+p73/ueKisr7W4SANiOQGkTl8ulxTOukOFyW3L8YCisof2z9A/vFyrfvovlg1qRaMMhYwtyNX30QFOOdcvoQbqs4JvayXp/QOXbd/F6idIpp5yijRs3qlOnTho2bJhKSkrsbhIA2IrxUBsNOrq7zhiQrfcq/6uwYX62v27p35v+25CUm5WhwkE5GjckV3m9qJtLpB7KiKmFeerRNV2zV5YrEAq3q6bS7TIUDgZ09clHaErhAFXu3K2lJV4Vb6qWt87XbItHXi+H169fP7333nsqKipSYWGhXnrpJV1wwQV2NwuAEqM+PtnQQ2mzX405SWmdPJLFL/6wpKo6n5aUVGnUA+s04akSbavzWXrORJCIHzpjC3K1ZtoIDeufLUmH3b4zcvuw/tna9ti1mn3dWA2f9aJGPbBOS0qqVHVQmJR4vUQrOztba9as0bnnnqsLL7xQTzzxhN1NAvC1RBuFSnQESps11cbF6YUf6dHasKVWIxet1bLS1N3vOxF7KCP6ZGVoyaQhevumMzVhSF/1zc5osV6AIalvdoYmDOmrNdPO1JJJQ3TqD36sY65+RN69nSXpsD2cvF4Or0uXLnr55Zd1/fXXa/LkyZo1a1bCvq4AoKMY8naAsQW5qtnj172rK/b3VMYhXAa/Hi6dsbxMNXv8mlqYZ/k5nSaRA2VEXq9umlOUrznKV70/oK219WoMhJTmcalfdmazWf4PF1dqZ7+RMsLhdn9z5/VyaG63Ww899JD69OmjGTNm6NNPP9Xjjz/OWpUAUgaB0iEOrI1r3BewpKayLfeurlDPrunNJmmkgmQbDslM9yi/d/dWb1tW6t3/hUWxX3eqvl4OxzAM3XbbbTr22GM1ceJE7dixQy+//DJrVQJICQx5O0ikNu70vJ6SZNmSQq2ZtbI85WrkkqGHMhrb6nyavbLc1GOm4uslWuPHj9cbb7yh9957T2eddZZ27txpd5OAlJMKn+1OQ6B0mD5ZGXp+0lC9deMZyt27VfvqtkstpkyYLxAKa+aKMsvP4zSp8KEzc0WZAibvA56qr5dojRo1SuvWrdP27dv1ve99TxUVFXY3CUg5yTYK5XQESocadHR3rV00VT8Ilmjb/Zfq+uO/1Irrh+nRcadacr5gKKz1m2u0uXq3Jcd3olTooazcuVvrN9eYumWjlJqvl/Y6+eSTtXHjRqWnp2vYsGF6//33m257+umntX79ehtbBwDmIlA6mMvl0hNPPKGJE36i26+boLI/v66SLXWHXSamo9wuQ8+/nzqzeBM9UIZCIZ177rm69dZb9d///rfV+ywt8fJ6sVHfvn313nvv6X/+53/0/e9/XytXrtQjjzyiSZMm6Zprrkno1x8AHIhA6XCRUHnVVVfpyiuv1Mq//cf03qaIYCis4orU2Zs40YdD/H6/3nrrLd1zzz3Kzc1tNVgWb6rm9WKzrKwsvf322/rBD36gH/3oR5oyZYokadOmTdqwYYPNrQMAczDLOwFEQmXA8Ki40WXpqkLeWp/+U/WpMtKs2RLSTA0NDdq7d6927NjRod//6quvFAqFOvz7dmtoaGj677179+q+++7Tb37zG1111VWaMWOGsnr1ltfiiTPeWp/q/YFmyxOhpS5duuimm27Sa6+91tQr6fF49Nhjj+n0008/5O8ebjkoAHACI8yYS8L4f59+qQt++57l59n+9M+0r/oTy88D6xxxxBHa8JFX5z/0F8vPtepnZ7S5XBH227Jli0499VTt3r1boVCo6eedOnXS559/rqysrGb3Z1tMIDa33367XnzxRW3ZssXupqQMvuYmkH0WDV0e7P4HH9LxCfA3av78+WpsbNTcuXM79PsrV67UM888oxUrVpjcsvjw+/26+OKLm/7tcrkUCoV00kknae7cuWoMhA7x2+aJ13kS2ZYtW+Tz+RQKheTxeBQIBCRJ+/bt05NPPqnbbrtN0v4lnmauKNP6zTVyu4xWyxUO3Bbz2Y1bNXxADy0YM1h9sjLieUmA4yV6WVOiIVAmkDRPfEpeC89MjB6np59+Wg0NDTr//PM79PtbtmyRy+Xq8O/bLTLkHZlcNGLECM2bN09nnHGGJKl8+664tCNer8tENnLkSH3xxRdav3693n77bf3pT3/SRx99JEn61a9+pdtuu03LSr2avbK8aYmn9m6LObcoX2NZbB6ATQiUCaRfdqYMWbsqpfH1eVJBon977dSpk3JycpSfn98sSEbwenGWzMxMnXvuuTr33HN133336fPPP9dzzz2n3bt36+HiyqadjNqLbTERL9Tz4lB4JSSQzHSPcrMyVGXhRIvc7IyU+YBI9GWDPB7PIXdh4fXibEcffbRuvfVWLSv1asZycxaJZ1tMmI16XkSLsaoEUzgox9J1BQsH5lhybCdK9EAZDV4vzsa2mHCqbXU+TXiqRKMeWKclJVWqOihMSs3reUc9sE4TnipxzGsv2T/bnYhAmWDGDcm1dF3B8UNTq2cj2T90eL04G9tiwomWlXo1ctFabdhSK6n99bzLSp2x4UGilzUlGgJlgsnr1U3DB/QwvdfJ7TI0fEAPDchJnSGLVOih5PXiXGyLCSd6uLhSM5aXyR8Itfu1GQyF5Q+ENGN5mR4urrSohXAqAmUCWjBmsDwmBwSPy9CCMYNNPabTpcq3V14vzsS2mHCaZaXeDk8OO9i9qyv0okN6KhEfBMoE1CcrQ3OL8k095ryi/JRbxy4VeiglXi9OxbaYcBLqeRErAmWCGluQq+mjB5pyrFtGD0rJWaGpEiglXi9Os8cfiNu2mEA0kq2eN1U+252EQJnAphbm6dcXDVa6x9XuoTO3y1C6x6W7LxqsKYUDLGqh86XShw6vF+eoqq23dH1Qaf8M3K219RafBckgWet5U6WsySkIlAlubEGu1kwboWH9syXpsEEhcvuw/tlaM21ESvc0peKHDa8XZ2BbTDgJ9bwwAysSJ4E+WRlaMmnINwvQVlTLW9t8zbBwOKzstJCKvnuCxg/NZXauUjNQStG9XgztX7S8cGAOrxcLxGu7SrbFRDTiUc87R+bWccN5CJRJJK9XN80pytcc5TfbIquTy9A9c27VkqcXa9rvfqcBObyxpW8CZTgcTslw2dbrhS3VrMe2mHCKeNbz8pmS3Hh2k1Rmukf5vbs3/fuZJx6TJxzUFVdcIUmaMGGCXU1zjFQPlAc6+PUCa7EtJpwinvW8fMYkNz5tUoTL5dKTTz4pSYTKg6TSxBw4R+GgHC0pqbJkqJFtMRGtZK3n5XM9/giUKYRQ2dyBPZRAvI0bkqtnN2615Nhsi4loJXM9b6qPPMUbgTLFECq/wYcN7BTZFnPDllpTeyndLkPD+mczkQpRoZ4XZmEKYAqKhMqJEyfqiiuu0JIlS+xuki3ooYTd2BYTdovU81qJet7UQKBMUYRKAiXsx7aYcILCQTmWrkNJPW9q4CtDCmP4ez8CJew0tiBXNXv8und1RczHYltMdEQy1vPyuR5/BMoUl8qhkh5KOMXUwjz16Jqu2SvLFQiF21VT6XYZ8rgMzSvKJ0yiQ5K1npc6+fgiUCJlQyUfNnCSsQW5Ov2EHpq5okzrN9fI7TIO+cc9cvuw/tlaMGYww9yIyYIxgzVy0VpTA6XHZWjWD/JMOx6cjUAJSakZKumhhNOwLSbsEqnnnbG8zLyDfvCSBh57ngYNGqTCwkKddtppKigo0Le+9S253W7zzgNHIFCiSaqFSgIlnOrgbTGffvl1Tb91hv78zhqd1P8YZszCEmbX8351xEDN/JO0adMmbd68WY899pgkqUuXLpo3b56mT58e83ngHHwqoZlUC5USgRLOlpnu0bEZYTXuqNCgXuyxDmuZWc/bePrP9eCDD2rnzp0KBoNN92toaFC3btb2rPO5Hn8sG4QWUmVJIXooAaClsQW5WjNthIb1z5akwy4pFLl9WP9srZk2omlyWFpamm677bYW9eqXXnqprr32Wgta3hx18vHFV120KhV6KvmwAYDWmVXPe80112jOnDn66quv5HLt78P64IMP9NFHH+nEE0+Mz8UgLgiUaFOyh0p6KAHg0A6u5z3xtBH6wQ+L9LOfXqd+2YcvwejatatuuOEG3XXXXerWrZtee+01/exnP9OQIUP07LPP6uKLL47TlcBqDHnjkA4e/n7++eftbpJpCJQAEL3MdI982yvUNzOk/N7do67nveGGG/S9731Py5cv11lnnaWNGzfqBz/4gS655BLdfvvtzeorkbjoocRhRUJlOBzW5ZdfLkkaP368za2KHYESANrH5/MpI6N9a5727NlTGzZsaPp3165d9eKLL6qgoEAzZszQ3//+d/3+979XVlaWae3kcz3+CJSIisvl0uLFiyUpqUKlxAcPAEQjHA53KFC2xjAM3XLLLTr55JM1duxYffe739Xy5ct18sknx97QA86B+GHIG1GLhMorr7xSl19+ecIPf/NhAwDR27t3rySZEigjRo0apQ8++EDdu3fXsGHD9MILL5h2bMQXPZRol2TqqWTIGwCi19DQIMncQClJ/fr103vvvafJkydr3Lhx+tvf/qaFCxfK4yGiJBKeLbRbsoRKAiUARM/n80kyP1BGjvncc8+poKBAN998s/7xj3/oxRdfVE5OjunngjUY8kaHJMPwN4ESAKIXCZRdunSx5PiGYeiGG27QO++8ow8//FDf+c53VFpa2u7j1PsD+tLoqtBRuSrfvkv1/oAFrcXB6KFEhyVLTyWBEgAOz8oeygONGDFCH3zwgS6++GINHz5cjz76qCZOnHjI32lagH1Ttbx1PoU7nSaNOE3nP/SX/QuwZ2WocFCOxg3JVV4va7d9TFUESsQkkUMlk3IAIHrxCpSSdNxxx2nt2rX62c9+pquuukqlpaV64IEHlJaW1ux+2+p8mrmiTOs318jtMlrdezwsqarOpyUlVXp241YNH9BDC8YMVp8s668jlRAoEbNEDZUMeQNA9OIZKCWpc+fOevLJJ1VQUKCpU6fqX//6l1555RUdc8wxkqRlpV7NXlmuwNchsrUweaDI7Ru21GrkorWaW5SvsV/vO47YEShhikQMlQRKAIhevANlxLXXXqvBgwfr4osv1ne+8x298sor+ru/p+5dXdGh4wVDYQVDYc1YXqaaPX5NLcwzucWpiUAJ0yRaqCRQAkD07AqUkvS9731PH3zwgf7v//5P5/3sLh05eoopx713dYV6dk3XZfRUxoxACVMlWqiUCJQAEI3IOpRWzfI+nGOOOUa/e3WVznlgncyctz1rZbmGndCDmsoYEShhukQJlUzKAYDo+Xw+paWlye1229aGOX/8WGGXWzpMvWR7BEJhzVxRpiWThph2zFREoIQl2gqVgUBAd911ly644AJ997vftbOJDHkDQDuYtY93R1Xu3K31m2tMP24wFNb6zTXaXL1bA3JYUqijCJSwzMGhMhgM6o9//KNeeeUVlZaWatWqVba2j0AJANGzO1AuLfG2uTRQrNwuQ8+/79WconzTj50qCJSwVCRUhkIhXXnllU0hbvXq1dq1a5e6d+9uW9sIlHCyUCikM844Q5999lnTZIj//d//lcvl0sUXX6z777/f5hYi1dgdKIs3VVsSJqX9vZTFFdWaIwJlR7H1IiwXCoVUX18v6ZvwFggEtHLlSjub1YRACScyDEP//e9/5fV6VVOzf5jv008/ldfrbXo/AfFkZ6Dc4w/IW+ez9BzeWh/bNMaAQAnL/fznP9crr7zS7Gcul0vLli075O/V+wMq375L//B+Ycl+rEzKgZMZhqG5c+e2+Lnb7dbMmTNtaBFSnZ2Bsqq2XlZ/9Q9L2lrLl7WOYsgbljvppJPUu3dvbd++XR6PR4FAQKFQSG+99VaLYe8W+7EecJyD92ONFUPe36j3B7S1tl6NgZDSPC71y85UZjofD3a77LLLNGvWLG3ZskXhcFhut1tXXXWV+vbta3fTkIJ8Pp9tSwY1BkJJdZ5kxF8MWG7SpElNe7G+9NJL+v3vf6/t27crGAzqwQcf1KxZszq0H2u3Y0erl/fdDrcr1QNle8J7Xi9mPtrB7XZr3rx5GjduXNPP7rjjDhtbhFTW0NBgWw9lmic+A6rtOQ9fxJtL3StHXBmGodNOO02nnXaa7rnnHpWUlOjOO+/UiBEjOrwf6+6M3toz6CdaVurt0H6sqRooOxLehw/ooQVjBrPwrw0uu+wy3Xzzzdq5c6fGjRtH7yRs4/P5dOSRR9py7n7ZmTIkS4e9ja/Pcyh8EW8bNZSIO8MwNHToUK1atUplod6asbxM/kCo/bP3DJfChlszlpfp4eLKDrcnlQLlslKvRi5aqw1baiVFH943bKnVyEVrtazUa3kb0Zzb7dZNN90kwzConYSt7KyhzEz3KNfiL7S52Rlt9jBuq/NpwlMlGvXAOi0pqVLVQWFSav5FfNQD6zThqRJts3gikZMQKGGbZaVe3bu6IraDfN3LeO/qCr3YzrCTapNyHi6u7HB4D4bC8gdCMYd3tF+9P6AfXn69/vqfagW6Hc0sVNjG7mWDCgflyO2y5nPb7TJUODCn1dv4Ih4dhrxhi211Ps1eWW7qMdu7H2sqDXmbEt6/du/qCvXsmq7LOlBmgOgwrAYnsjtQjhuSq2c3brXk2MFQWPnpdSorK5PL5Wr63+///YWe/Xtth48ZDIU1Y3mZavb4NbUwz+RWOwuBEraYuaKsqWbSLO3djzVVAqUTwjuiQ30rnMzuQJnXq5uGD+ihDVtqTV3g3O0y1CNYq0vPvaDZz7ueNFrZ591gyjlS4Ys4Q96Iu8h+rGbveHDgfqzRSJVAaWV4h3kYVoPT2blsUMSCMYPlMXnY2+MytPjas5Wdnf3Nz7r30lGjJpv692HWyvKkrqkkUCLuIvuxWiGyH2t7JHOgdEp4x6FR34pEYHcPpST1ycrQXJP3255XlK/B/XtrzZo18nj2D9xmnTtFhsttaq19sn8RJ1Ai7uKxH2s0UmFSjtPCO1oyu761vZPTgGiEw2Fb16E80NiCXE0fPdCUY90yelDTMPTJJ5+sRYsWqVN2H3U5/lQZbnOrApP9iziBEnHlpP1YU2HI247wvnfvXj333HNav369JedNJlbVtybzsBrssXfvXklyRKCUpKmFefr1RYOV7nG1+0uz22Uo3ePS3RcN1pTCAc1umzJlik66aIrCoaCZzW127mT9Ik6gRFw5aT/WZA+U8Q7vX3zxhRYsWKDjjjtOV1xxhe6++25Lz50MqG9FovD59n+WOCVQSvt7KtdMG6Fh/ffXPh4uWEZuH9Y/W2umjWh1goxhGOp8wndkuNzmN1jtG0VLNMzyRlw5aT/WZA+U8QrvG8oq9fpzj+rJJ59UY2OjQqH9j33nzp0tPntii9S3mu3AYbUBOSwpBHM4MVBK+2sql0wa8s1SWxXV8ta2stRWdoYKB+Zo/NDcQ74v9vgD+uxLv6VtjnwRT7ZtGpPrauB4TtqPNdkDZbzC+wVFP1LjjpY1gOvWrdPo0aPVpUsXZWRkqEuXLk3/O9S/D3Vb586d5XIlx8BKpL7VipKEyLDaHJMnLyB1OTVQRuT16qY5Rfmao/yY9tiO5yhafu/uFp8pvgiUiCun7MeaCuIV3r976sna+EalDMNo6p00DENHHnmkunfvroaGBu3cuVMNDQ1qaGiQz+dr+u/Iv9ujc+fOMQfTaH+3U6dOlk3eikd96xwRKGGOyPvU7mWDopGZ7ulwWHPSKFqiIVAiriL7sVZZWNt3qP1YD5TsPZTxCu+rX12q7d67NGPGDC1fvlxut1vhcFjnnXeeHnjggcMeIxwOy+/3txo4Wwufh7utvr5eNTU1bd63sbEx6utzuVym9rBG/i1PetzqW5NtWA32cHoPpVmcNIqWaPikQdwVDsrRkpIqy4b62tqP9WDJHijjGd7z8vL06quv6v3339fNN9+sjRs3qnv36HoIDMNQ586d1blzZx111FGWtTUiGAw2C6IdDa6R/9XV1emzzz5r876RXtsDdco5Xr2vesjS60zWYTXYI1UCJaNoHUegRNxZvR/r+KHRbW2V7IFSin94Hzp0qN577z299957+p//+R/Tz2kGt9utrl27qmvXrpafKxwOa9++fS3C6L8++0ozi+ssP38yDqvBHg0NDZKSP1A6aRQt0SRfnyscL7Ifq9kLbrtdhoYP6BH1zNZUCJTjhuRaWqfXWng3DENnnHGGevToYcl5E4lhGEpLS1P37t119NFHq3///srPz9f/fvvEuJw/GYfVYI9U6aGU9n8Rt3JDiGhH0RINnzawhVX7sS4YM9jUYyY6p4R3NBcZVrNSsg6rwR6JNCknVnZ8EU8GBErYwqr9WPtkRf/tORV6KCXCuxNFhtWslKzDarCHz+dTenq63G5rFvx2Er6IdwyBErYxZT/Wr8PggfuxRitVAqUTwjtaYlgNicTn86VE72QEX8Tbj0AJW8WyH6vCIRnhYKv7sUYjVQKlZFJ4/1pHwjtaYlgNicTn86VE/WQEX8Tbj0AJ23V0P9Zuvu06YdMLHQ43qRQopdjCu9tlKN3j6nB4R0sMqyGRpFqglPgi3l4ESjhCZD/Wt286UxOG9FXf7IwWkxYMSX2zMzRhSF+tmXamBn62WmmNu+1obsLqaHgf1j9ba6aNSPoPxHhjWA2JIhUDpcQX8fagYhuOcvB+rL955veaM+8ulZZs1Ak5R5g6ySDVeigjIuG9cuduLS3xqriiWt5aX7OFfA3tn9RRODBH44fm0ttlkciw2ozlZaYdM9mH1WCPhoaGlAyU0v4v4qef0EMzV5Rp/eYauV3GIctVIrcP65+tBWMGp8z7kUAJx8pM9+jo9IAad1Qov3d302cXpmqgjDg4vG+trVdjIKQ0j0v9sjOZIRwnYwtyVbPHr3tXV8R8rFQYVoM9UrWHMoIv4ofHXww4mpVhL9UD5YEy0z1s0WejqYV56tE1XbNXlisQCrdrso7bZcjjMjSvKJ8wCcukeqCMOPCL+M7aL3X8SafpiCOz9M7bb6X8F3FqKOFokbAXCX9mIlDCSahvhZOl2rJB0XjkN4vUsL1SOz8s0a6t5SkdJiV6KOFwVgZKwGkYVoNT+Xw+HXvssXY3wzF27NihhQsXStr/92nhwoV67bXX7G2UzQiUSAj0UCKVUN8Kp2HIu7lZs2Zp3759kvb/DVm5cqUqKyuVl5dnc8vsw5A3HI0aSqS6SH3rKblHKb93d8IkbEGg/EZ5ebmeeuopBYPBpp+53W4tWrTIxlbZj0AJRyNQAoD9CJTfuO+++xQOh9WpUydJksvlUiAQ0NNPP62vvvrK5tbZh6+6cLRwOGxZ/SSBEgCik8rrUB7s+uuvV//+/VVfX69f//rXOv3005Wbm6suXbo0hcxURKCEo1kZKAEA0WGW9zcKCgpUUFAgn8+nX//615o8ebLGjRtnd7Nsx5A3HI8eSgCwTygUooeyFT6fT5J4XL5GoISjMeQNAPbau3evJILTwQiUzREo4WgESgCwF8GpdTwuzREo4WjM8gYAexGcWsfj0hyBEo7GpBwAsBfBqXU8Ls0RKOF4DHkDgH0ITq1raGiQxOMSQaCEo1FDCQD2Iji1jqDdHIESjkagBAB7EZxax+PSHIESjkagBAB7RYITC5s3x+PSHIESKYvJPgBwePTEtc7n86lz585yuYhSEoESDhePWd70UAJA2+iJa53P5yNkH4BACUdjyBsA7OXz+ZSeni632213UxyFQNkcgRKORqAEAHsRnFrH49IcgRKORqAEAHs1NDQQnFrh8/koAzgAgRKOZ3WgBAC0jZ641vG4NEeghKPFo/eQHkoAaBvBqXU8Ls0RKOFoDHkDgL0Y2m0dpQDNESjhaARKALAXPXGt43FpjkAJRyNQAoC9CE6t43FpjkAJx2NSDgDYh+DUOh6X5giUcDQm5QCAvQhOreNxaY5ACUdjyBsA7MXkk9YRKJsjUMLRCJQAYC+CU+t4XJojUMLRCJQAYC+WDWodgbI5AiUczcqwx6QcADg8glNLwWBQfr+fx+UABEo4ntXBjx5KAGgbgbKlhoYGSeJxOQCBEo7GkDcA2CcUCmnv3r0Ep4P4fD5JBMoDESjhaARKALAPPXGtI1C2RKCEoxEoAcA+BMrWRR4XJit9g0AJR2NSDgDYh5641vG4tESghOMxKQcA7EFwah2PS0sESjgaQ94AYJ9IcGJotzkCZUsESjgagRIA7ENwah2PS0sESjhaPGooCZQA0DqCU+t4XFoiUMLR4tFDCQBoHcGpdZHHpXPnzja3xDkIlHA8JuUAgD0IlK2L7B5Ex8Q3CJRwNGooAcA+rLfYOrajbMljdwOAg1VVVamoqEi7d+/WF198oT179igvL08ul0u//OUvNX78eFPOQ6AEgEPz+Xzq3LmzXC76nw5EoGyJQAnH6dy5sz7++GM1NjY2/Wzz5s2SpPr6etPOQ6AEgEMjOLWOx6UlvnLAcXr16qXJkyfL7XY3/cwwDB1zzDG68sor7WsYAKQYn8/HcHcrCJQtESjhSDNmzGg2xBIOhzV79mylp6ebdg56KAHg0AhOrWtoaOBxOQiBEo7Uu3dvTZ48uSn0HXvssZo4caKp5yBQAsChEShbx+PSEoESjjVjxoym0Dd79mylpaWZenwCJQAcGsGpdTwuLREo4VjHHnuszjzzTHXp0kVXXHGF6ccnUALAoTG02zpqS1tiljccq94f0ENLVqh+r1+VNQ3ql+1SZnpyvGTr/QFtra1XYyCkNI9L/bIzk+baACQPeuJax+PSEn/B4CiVO3draYlXxZuq5a3z6cC+Q0NSblaGCgflaNyQ3JjPFe8eyvZcW16vbnFpEwAcis/nU48ePexuhuMQKFsiUMIRttX5NHNFmdZvrpHbZSgYahnywpKq6nxaUlKlZzduVbdjR6uX990OnzNegbIj1zZ8QA8tGDNYfbL4wAJgH4Z2W0egbIkaSthuWalXIxet1YYttZLUauA6UOT23Rm99Z9BP9GyUm+HzhuPQNnRa9uwpVYjF63t8LUBQEft27dPH374oT755BPt2rVLHo9HwWDQ7mY5CoGyJQIlbPVwcaVmLC+TPxA6bNhqwXApbLg1Y3mZHi6ubPe5rQ6UsVxbMBSWPxDq8LXFW70/oPLtu/QP7xcq375L9f6A3U0C0EFz585Vfn6++vfvrw8//FCLFy+Wx+PREUccoU2bNtndPEcgULbEkDdss6zUq3tXV8R2kK9D4b2rK9Sza7ouK4i9ttIMplzb15x2bRHUhALJ6eyzz9b8+fNb/NzlcqlXr142tMh5CJQt0UMJW2yr82n2ynJTjzlrZbm21fmivr9VPZROuDYrbavzacJTJRr1wDotKalS1UFhUmpeEzrqgXWa8FSJY9oP4NDOOussnXTSSc12KzMMQ3PmzNGRRx5pX8McIhAIaN++fdSWHoRACVvMXFGmQHuHuA8jEApr5oqyqO9vVaB0wrVZhZpQIPkZhqEZM2YoFAo1/axPnz766U9/amOrnMPn2//lODMz0+aWOAuBEnFXuXO31m+uaX/N5GEEQ2Gt31yjzdW7o7q/FYHSKddmhVSqCYW1qLl1vksuuUS9e/du+vfChQtN360sUTU0NEgSQ94HoYYScbe0xNvm8jmxcrsMPf++V3OK8g97344Eyh07dmjdunX60Y9+pPT09Ba3O+XazJYKNaGwFjW3iaVTp0664YYbNGPGDPXr10+XXnqp3U1yjEgPJYGyOXooEXfFm6otCVzS/p6w4opqS44tSb/73e80duxY9e3bV4888oj8fn+z2xP52tqS7DWhsBY1t4nr2muvVc+ePXXPPfc0fQEHgbItBErE1R5/QF6L/1B4a33tGkJrTw9lMBiUy+XSzp07NXXq1GbB0onXZoZkrgmFtai5TVz1/oC2N7j01t826VvDRlGWcAACZesY8kZcVdXWt+idMFtY0o8mXKMue2ujuv/DDz+s119/Par7VlRUNAXQcDisnTt3asqUKbr55pt1z+LfKyxra4zCkrbW1iu/d3dLzxMRqQk124E1oQNyGN5MRg8XV3a4TCIYCisYCmvG8jLV7PFramGeya1DayhLiA6BsnUESsRVYyB0+DuZIOxyt2uIJtr7tnU/wzAUjFOHf7weQyl5a0JhLWpuEwvbw7ZPJFCybFBzBErEVZonPqHrwfvvi6oXz+Px6Prrr9d1110X1XHnz5+vWbNmNfVSHnPMMZo1a5YmTpyozbV79UD5X2JqdzTi9RhK8akJnaNvAmU4HNYbb7yhRx99VDfddJNGjhxpyblhHatqboed0CMlw4vVlpV6NXtleVNZS3vLEuYW5WtsioV9eihbRw0l4qpfdqasLu02vj6PFdxut0KhkI455hg9+uij+uSTT3TdddcpPT094a/tYPGsCQ0EAnrhhReUn5+vCy64QKtWrdL7779v6blhDWpuEwdLgXUMgbJ19FAirjLTPcrNylCVhUElNztDmenRvbQNw2jXpJwrrrhC/fv314UXXthi2SCnXVus4lXvesu8hVr+1G+0c+fOppICt9stl8ulYDAot9ttcStgFmpuEwdlCR3n8/nkcrlYl/MgBErEXeGgHC0pqbKsLq9wYE7U929voDzmmGMOuR6bk64tVvGq1Xzqmd+pcedOSd/MuA8Gg7rjjjt0xx13NH1wp6WlKT09vem/nfQzj8fDsiqyr+a2oqJC3bp10zHHHGP6eZMRZQmxiezjzXu+OQIl4m7ckFw9u3GrJccOhsIaPzT6b8ntDZSH46Rri1W8ajXHXnqJXnnyAe3du7fZVm9XXnmlzjzzTDU2NqqxsVF+v7/pvw/8X2s/37NnT1T3i/w8GAzGfB12htto7tupU6dmezNbIZ41t+FwWOvXr9eCBQv01ltvady4cXr++ectOXeysbIsYcmkIaYe14kigRLNESgRd3m9umn4gB7asKXW1D8+bpehYf2z2zUkZnagdNK1xSpSE2rlsLch6ZG75+qB2dO1cOFCLVq0SIFAQMFgUGeccYYmTpxo4dm/EQwGtW/fvkOGz/YE2oN/1tZ9vvrqq6iPt2/fvpiv0+PxmBpSD/yZu3OmvHXHmfBstM1b69PuhkateXOV5s+frw8++EBu9/4VHQ78MoK2UZYQOwJl6wiUsMWCMYM1ctFaU0OXx2VowZjBph2vo5Ll2uJZE5qZfpR+9atf6YYbbtC8efO0ePFi9enTx7LzHsztdsvtdqtz585xO2d7hcPhQ4beaENwe3/m8/miOqeR1UdH/XihtY+BpOO+dYq+qvqw6WfBYFCGYej//b//pzlz5qhz587q3Lmz0tPTW/3vQ92Wnp6e9OULLAUWOwJl6wiUsEWfrAzNLcrXjOXmzdycV5Tf7vods3soJedcmxniXRMamT3/m9/8Rh4PH08HMgyjqUfQif7h/UJjHt1g+XlcnpbXHw6HVVVVpcWLF2vv3r3y+/3au3evAoH27+7icrmiCp7RBtSO3K9Tp06Whdp4LwWWjBoaGgiUreATG7YZW5Crmj3+2GYahsOSYeiW0YM6NMPQikApmXRtX+votZnBrprQTp06WXJOWCdeNbdri99R6eoVuuOOO1RdXa1wOCyPx6OJEyfqgQceaHbfYDDYFC4PDJqt/bsj96utrW12vwNvj/x/Y2Njh67TivCqTp3lrbM2CEWWAovXahR2oIeydcn7jCMhTC3MU4+u6U0L67brm3M4JCMc0q8vPqXDgcuqQCnFdm1ulyGPy9C8onxbl+JIpppQWCteNbcn5ByhkyZN0k9+8hM99NBDuuuuu7R79+4Wy3hJ+0sZMjIybP3jHwqF5Pf7ow6p7Qm0e/fu1ZdffnnY+/r9fklSp5zj1fuqhyy93nhvD2sHAmXrCJSw3diCXJ1+Qo/Dbv0VEbm9m2+7ennf1WUFF3b43FYGSqnj1zasf7ZjtjVLlppQWCve67B26dJFt956q6655ho9/vjjOv/88y07byxcLpe6dOli6zZ9oVBIjY2NKv2kRhOe+5fl54vn9rB2IFC2jkAJR+iTlaElk4aocuduLS3xqriiWt5aX7PeDkP7/6AUDszR+KG5uu36K9XQ2GBXk6PWkWtzUs9dMtWEwlp2rMN61FFHacaMGaafL5lE6kKzusfncyWe28PawefzKSsry+5mOA6BEo6S16ub5hTla47yVe8PaPL0X+hfZeVa9sLz6pedaXpdjtU9lAc6+Nq21tarMRBSmsdlybWZKVlqQmGtZFqHNRnFqywhXtvD2oUeytY59y8YUlZtba0efPBB+f1+ffje26r+7DM99+ACSdLll1+u/HzzZhDGM1AeKDPdk3A1RslQEwprUXPrbMm2PaxdCJStS+5nHQnpP//5j+68886mXT3C4bDuv/9+BQIBHXPMMUkRKBNVMtSEwlrU3DpbMm0PaxcCZeuSu9ABCamgoECnnXZa0+4X4XBYgUBAXbt21ZVXXmn6+QiU7ROpCX37pjM1YUhf9c3O0MEr5hmS+mZnaMKQvloz7UwtmTSEMJkiIjW3ZqLm1jzjhuRaug5lKpQlEChbRw8lHMcwDN11110aPXp0089cLpemT5+uI4880vRzoWMSuSYU1qLm1rkoS4gdgbJ19FDCkUaOHNnUSylJGRkZuvHGG00/D0Pe5ojUhJ6Se5Tye3cnTEJTC/P064sGK93jktvVvi9ubpehdI9Ld180WFMKB1jUwtS1YMxgedr5nBxOqpQlhMNhAmUbCJRwpEgvZSTsWdE7GTkPgRKwxtiCXK2ZNkLD+mdL0mGDZeT2Yf2ztWbaCHomLUJZQsft27dPwWCQQNkKuhHgWCNHjlSvXr303//+15LeSYlACVgt0ddhTVaUJXRMQ8P+tY8JlC0RKOFYvsagHnlhpbZu+1Sf+Qx16mLN/rAESsB61Nw6D0uBtZ/Pt3/JJQJlS7yD4ShNvRibquWti/RipOs3H/9lfy9GVoYKB+Vo3BBzPsDooQTiLxHXYU1WLAXWPgTKthEo4Qjb6nyH/UALS6qq82lJSZWe3bhV3Y4drV7ed2M6L7O8AaQ6yhKiR6BsG4EStltW6m0acpF02GGXyO27M3prz6CfaFmpV2M7OORCDyUA7EdZwuERKNvGqwO2eri4suNF4YZLYRmasbxMNXv8mlqY1/5DECgBoAXKEloXCZRdunSxuSXOw7JBsM2yUm/sMwy/HrK+d3WFXiz1dugQBEoAQDTooWwbgRK22Fbn0+yV5aYec9bKcm2r87Xrd+ihBABEi0DZNgIlbDFzRVlTzaRZAqGwZq4oa9fvMCkHABAtAmXbCJSIu8qdu7V+c42p+8hK+yfrrN9co83Vu6P+HXooAQDR8vl88ng86tSpk91NcRwCJeJuaYm33Xv7RsvtMvT8+9HXUhIoAQDRYh/vthEoEXfFm6pN752MCIbCKq6obtfvECgBANEgULaNQIm42uMPyNvOiTPt5a31qd4fiOq+9FACAKJFoGwbgRJxVVVbL6vjW1jS1tr6qO7LpBwAQLQaGhoIlG0gUCKuGgMhR52HHkoAQLTooWwbgRJxleaJz0su2vMQKAEA0SJQto1Aibjql50pqweZja/PEy0CJQAgGgTKthEoEVeZ6R7lZln7ZszNzlBmenTb1NNDCQCIFoGybQRKxF3hoBxL16EsHJgT9f2ZlAMAiJbP51OXLl3sboYjESgRd+OG5Fq6DuX4oblR358eSgBAtOihbBuBEnGX16ubhg/oYXovpdtlaPiAHhqQ0y3q3yFQAgCiRaBsG4EStlgwZrA8JgdKj8vQgjGD2/17BEoAQDQIlG0jUMIWfbIyNLco39RjzivKV592TvihhxIAEC0CZdsIlLDN2IJcTR89MLaDfB0Gbxk9SJcVRF87GcGkHABAtAiUbSNQwlZTC/P064sGK93jan9NZTgkIxzU3RcN1pTCAR06Pz2UAIBohMNhAuUhEChhu7EFuVozbYSG9c+WpMMGy8jt3XzbdcKmFzrUMxlBoAQARKOxsVHhcJhA2QYCJRyhT1aGlkwaordvOlMThvRV3+yMFjvqGJL6ZmdowpC+WjPtTA38bLXSGnfHfG4CJQDgcHw+nyQRKNsQ3XYiQJzk9eqmOUX5mqN81fsD2lpbr8ZASGkel/plZ0a9A0606KEEAESDQHloBEo4Vma6R/m9u1t6DiblAACiQaA8NIa8kdLooQQARINAeWgESqQ0AiUAIBqRQMle3q0jUCLlESgBAIdS7w/o4517lHbMQG33uVTvD9jdJMehhhIpjR5KAEBrKnfu1tISr4o3Vctb51NY0jFX3K9rlm+RsXyLcrMyVDgoR+OG5CqvVze7m2s7AiVSGpNyAAAH2lbn08wVZVq/uUZul6FgqGWnQ1hSVZ1PS0qq9OzGrRo+oIcWjBnc7u1/kwlD3khp9FACACKWlXo1ctFabdhSK0mthskDRW7fsKVWIxet1bJSr+VtdCp6KJHyCJQAgIeLK3Xv6ooO/W4wFFYwFNaM5WWq2ePX1MI8k1vnfPRQIqXRQwkAWFbq7XCYPNi9qyv0Ygr2VBIokdIIlACQ2rbV+TR7Zbmpx5y1slzb6nymHtPpCJRIaUzKAYDUNnNFmQKHqZVsr0AorJkrykw9ptMRKJHS6KEEgNRVuXO31m+uOezkm/YKhsJav7lGm6t3m3pcJyNQIuURKAEgNS0t8crtsmakyu0y9Pz7qVNLSaBESqOHEgBSV/GmatN7JyOCobCKK6otObYTESiR0giUAJCa9vgD8lo8ccZb60uZbRoJlEhpTMoBgNRUVVsvq7sTwpK21tZbfBZnIFAipdFDCQCpqTEQSqrz2I1AiZRHoASA1JPmiU8Eitd57JYaVwm0gR5KAEhN/bIzZXXRk/H1eVIBgRIpjUAJAKkpM92j3KwMS8+Rm52hzHSPpedwCgIlUhqTcgAgdRUOyrF0HcrCgTmWHNuJCJRIafRQAkDqGjck19J1KMcPzbXk2E5EoETKI1ACQGrK69VNwwf0ML2X0u0yNHxADw3I6WbqcZ2MQImURg8lAKS2BWMGy2NyoPS4DC0YM9jUYzodgRIpjUAJAKmtT1aG5hblm3rMeUX56mPxhB+nIVAipTEpBwAwtiBX00cPNOVYt4wepMsKUqd2MiI15rIDbaCHEgAgSVML89Sja7pmryxXIBRu12Qdt8uQx2VoXlF+SoZJiR5KgEAJAJC0v6dyzbQRGtY/W5IOO1kncvuw/tlaM21EyoZJiR5KpDh6KAEAB+qTlaElk4aocuduLS3xqriiWt5anw78S2Fo/6LlhQNzNH5obkrN5m4LgRIpjUAJAGhNXq9umlOUrznKV70/oK219WoMhJTmcalfdmbK7IATLR4NpDQm5QAADicz3aP83t3tboajUUOJlEYPJQAAsSNQIuURKAEAiA2BEimNHkoAAGJHoERKI1ACABA7AiVSGpNyAACIHYESKY0eSgAAYkegRMojUAIAEBsCJVIaPZQAAMSOQImURqAEACB2BEqkNCblAAAQOwIlUh49lAAAxIa9vJFQVq9eraKiIgWDQQWDQUlSp06d5HK59PLLL6uoqKhdx2PIGwCA2BEokVD69OmjxsbGZiEwEAhIknJzc9t9PAIlAACxY8gbCeVb3/qWLrvsMnk833wX8ng8uvDCC3XyySe3+3gESgAAYkegRMKZNWtW03C3tL+Hcs6cOR06FpNyAACIHYESCSfSS2kYhgzD6HDvZAQ9lAAAxIZAiYQ0a9YshcNhhcPhDvdOSgx5AwBgBiblICF961vf0tChQ7V3796YeicNw1AoFDKvYQAApCACJRJSvT+gxa++qcZASOXbd6lfdqYy09v3cq73B+TP6Kl9wXCHjwGgpXp/QFtr69UYCCnN4+K9BaQAI8x4HxJE5c7dWlriVfGmannrfDrwhWtIys3KUOGgHI0bkqu8Xt0sOwaAlnhvAamNQAnH21bn08wVZVq/uUZul6FgqO2XbOT24QN6aMGYweqTlWHaMQC0xHsLgESghMMtK/Vq9spyBULhQ/6hOpjbZcjjMjS3KF+SYj7G2IL2L5oOJDsz3p+8t4DkQKCEYz1cXKl7V1fY3QxJ0vTRAzW1MM/uZgCOYdb7k/cWkBxYNgiOtKzU65gwKUn3rq7Qi6Veu5sBOIKZ70/eW0ByIFDCcbbV+TR7ZbndzWhh1spybavz2d0MwFZWvD95bwGJj0AJx5m5okyBdtRjxUsgFNbMFWV2NwOwlRXvT95bQOIjUMJRKnfu1vrNNe0q8I+XYCis9ZtrtLl6t91NAWxh1fuT9xaQ+AiUcJSlJV65XYbdzWiT22Xo+fep90JyeuWVV/TUU0+psbGx1dutfH/y3gISG4ESjlK8qdqRvZMRwVBYxRXVdjcDsMScOXN09dVX6/jjj9cTTzzRIlha+f7kvQUkNgIlHGOPPyBvAhTme2t9qvcH7G4GYJkdO3Zo8uTJzYJlPN6fvLeAxMXmqnCMqtp6Obdv8hthSaeOOEeuXdvtbgpgqi1btkiSIssTb9++XZMnT9aNN96otf/+j+Xvz7CkrbX1yu/d3eIzATAbgRKO0RgI2d2EqA0bPkLZ4a/sbgZgqmeffVa1tbVN/zaM/fWSp556qlyetLi0IZE+BwB8g0AJx0jzJE4FxvRpN9KLgqTz5ptvqra2Vm63W5J01VVXaebMmerXr5/Kt++KSxsS6XMAwDcIlHCMftmZMiTHD3sb2t9WINlkZGTI7XZr4sSJuuOOO9SvX7+m2+Lx/uS9BSQuAiUcIzPdo9ysDFU5fGJObnaGMtN56yD5vPjii3K73crNzW1xWzzen7y3gMTF2AIcpXBQjuPXoSwcmGN3MwBLHH/88a2GyQgr35+8t4DERqCEo4wbkuv4dSjHD237Dy6QzKx8f/LeAhIbgRKOkterm4YP6OHIXkq3y9DwAT00IKeb3U0BbGHV+5P3FpD4CJRwnAVjBsvjwEDpcRlaMGaw3c0AbGXF+5P3FpD4CJRwnD5ZGZpblG93M1qYV5SvPlkZdjcDsJUV70/eW0DiI1DCkcYW5Gr66IF2N6PJLaMH6bIC6rsAydz3J+8tIDkY4cgeW4ADLSv1avbKcgVC4XZNBnC7DHlchuYV5SssxXwM/uABLZnx/uS9BSQHAiUcb1udTzNXlGn95hq5XcYh/3BFbh8+oIcWjBncNIxmxjEAtMR7C4BEoEQCqdy5W0tLvCquqJa31tdsxw5D+xdFLhyYo/FDc9ucLWrGMQC0xHsLSG0ESiSken9AW2vr1RgIKc3jUr/szHbvsGHGMQC0xHsLSD0ESgAAAMSEWd4AAACICYESAAAAMSFQAgAAICYESgAAAMSEQAkAAICYECgBAAAQEwIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJgQKAEAABATAiUAAABiQqAEAABATAiUAAAAiAmBEgAAADEhUAIAACAmBEoAAADEhEAJAACAmBAoAQAAEBMCJQAAAGJCoAQAAEBMCJQAAACICYESAAAAMSFQAgAAICYESgAAAMSEQAkAAICYECgBAAAQEwIlAAAAYkKgBAAAQEwIlAAAAIgJgRIAAAAxIVACAAAgJgRKAAAAxIRACQAAgJgQKAEAABATAiUAAABi8v8BRZ0v/RMgHKoAAAAASUVORK5CYII="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# get node dataset from data service\n",
     "centerville_epn_link = '5b1fdc2db1cf3e336d7cecc9'\n",
@@ -96,7 +152,7 @@
     "# instead of reading it from the graph file\n",
     "g, node_coords = NetworkUtil.create_network_graph_from_link(link_filepath, fromnode_fldname, tonode_fldname, is_directed=True)\n",
     "print(node_coords)\n",
-    "print(nx.info(g))\n",
+    "print(g)\n",
     "nx.draw(g, node_coords)"
    ]
   },
@@ -109,9 +165,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-23T14:57:26.735406Z",
+     "end_time": "2023-10-23T14:57:26.887482Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset already exists locally. Reading from local cached zip.\n",
+      "Unzipped folder found in the local cache. Reading from it...\n",
+      "Dataset already exists locally. Reading from local cached zip.\n",
+      "Unzipped folder found in the local cache. Reading from it...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/lz/cytsgpz97f34yd69304b9vyc0000gr/T/ipykernel_12874/3196477836.py:18: FionaDeprecationWarning: This function will be removed in version 2.0. Please use CRS.from_epsg() instead.\n",
+      "  NetworkUtil.build_link_by_node(node_filename, graph_filename, id_field, out_filename)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": "True"
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# this process can be done using the local shapefile, \n",
     "# instead of using the dataset from the incore data service.\n",
@@ -142,9 +230,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-23T14:57:30.115378Z",
+     "end_time": "2023-10-23T14:57:30.191292Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset already exists locally. Reading from local cached zip.\n",
+      "Unzipped folder found in the local cache. Reading from it...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/lz/cytsgpz97f34yd69304b9vyc0000gr/T/ipykernel_12874/1565815967.py:20: FionaDeprecationWarning: This function will be removed in version 2.0. Please use CRS.from_epsg() instead.\n",
+      "  NetworkUtil.build_node_by_link(link_filename, link_id_field, fromnode_field, tonode_field, out_node_filename, out_graph_filename)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": "True"
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# this process can be done using the local shapefile, \n",
     "# instead of using the dataset from the incore data service.\n",
@@ -190,9 +308,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "start_time": "2023-10-23T14:57:33.444367Z",
+     "end_time": "2023-10-23T14:57:34.943261Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "network dataset is created with id 6536d02dfaa0854c4fb04416\n",
+      "attching files to created dataset\n"
+     ]
+    }
+   ],
    "source": [
     "dataset_prop = {\n",
     "  \"title\": \"Test epn network\",\n",


### PR DESCRIPTION
This PR fixed the issue https://github.com/IN-CORE/pyincore/issues/422
`info` has been removed from networkx 3.0 because it's deprecated. 
`print(nx.info)` is equivalent to `print(g)`

For testing, you can run the notebook create_network_dataset.ipynb