### PR TITLE
Fixes #289 - added Slack channel information to getting started and contact page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## [Unreleased]
+### Added
+- Slack channel information to getting started and contact page [#289](https://github.com/IN-CORE/incore-docs/issues/289)
 
 ### Changed
 - Update damage analysis documentations with hazard object input [#282](https://github.com/IN-CORE/incore-docs/issues/282)

--- a/manual_jb/content/contact.md
+++ b/manual_jb/content/contact.md
@@ -1,5 +1,9 @@
 # Contact Information
 
-* Contact [NCSA](http://www.ncsa.illinois.edu/) team via <incore-dev@lists.illinois.edu> regarding use of IN-CORE. The team will try to respond within 24 hours during business days.
+* You can contact the [NCSA](http://www.ncsa.illinois.edu/) team via <incore-dev@lists.illinois.edu> regarding
+  the use of IN-CORE. The team will try to respond within 24 hours during business days.
+* You can also reach out through our Slack channel. To get started, go to
+  [https://in-core.slack.com/](https://in-core.slack.com/). Or, you can grab an invitation here: [https://join.
+  slack.com/t/in-core/shared_invite/zt-25zffgnae-h0v8uGjpSli1YYp0Ypr68Q](https://join.slack.com/t/in-core/shared_invite/zt-25zffgnae-h0v8uGjpSli1YYp0Ypr68Q)
 * Please review [FAQ section](faq) before contacting the team.
 

--- a/manual_jb/content/contact.md
+++ b/manual_jb/content/contact.md
@@ -3,7 +3,6 @@
 * You can contact the [NCSA](http://www.ncsa.illinois.edu/) team via <incore-dev@lists.illinois.edu> regarding
   the use of IN-CORE. The team will try to respond within 24 hours during business days.
 * You can also reach out through our Slack channel. To get started, go to
-  [https://in-core.slack.com/](https://in-core.slack.com/). Or, you can grab an invitation here: [https://join.
-  slack.com/t/in-core/shared_invite/zt-25zffgnae-h0v8uGjpSli1YYp0Ypr68Q](https://join.slack.com/t/in-core/shared_invite/zt-25zffgnae-h0v8uGjpSli1YYp0Ypr68Q)
+  [https://in-core.slack.com/](https://in-core.slack.com/). Or, you can grab an invitation here: [https://join.slack.com/t/in-core/shared_invite/zt-25zffgnae-h0v8uGjpSli1YYp0Ypr68Q](https://join.slack.com/t/in-core/shared_invite/zt-25zffgnae-h0v8uGjpSli1YYp0Ypr68Q)
 * Please review [FAQ section](faq) before contacting the team.
 

--- a/manual_jb/content/getting_started.md
+++ b/manual_jb/content/getting_started.md
@@ -228,3 +228,6 @@ If you have problems running Notebooks, check our [WIKI questions](https://opens
 * IN-CORE's Frequently Asked Questions ([FAQ](faq)) and [WIKI Questions](https://opensource.ncsa.illinois.edu/confluence/display/INCORE1/questions/all) for detail information. 
 
 * The Building analysis Jupyter Notebook is also available at [IN-CORE project](https://github.com/IN-CORE/incore-docs/blob/main/notebooks/bridge_dmg.ipynb) on GitHub.
+* Our Slack channel is now open to the community. To get started, go to
+  [https://in-core.slack.com/](https://in-core.slack.com/). Or, you can grab an invitation here:
+[https://join.slack.com/t/in-core/shared_invite/zt-25zffgnae-h0v8uGjpSli1YYp0Ypr68Q](https://join.slack.com/t/in-core/shared_invite/zt-25zffgnae-h0v8uGjpSli1YYp0Ypr68Q)


### PR DESCRIPTION
I added the slack channel link and slack registration link in two places, 1) Getting Started page under "Useful Links" and 2) Contact Information page

Here is the Getting started page screenshot:
![getting-started-slack](https://github.com/IN-CORE/incore-docs/assets/2397115/67827b18-3526-4bf9-a085-61e69daafde2)

Here is the Contact Information page screenshot:
![contact-info-slack](https://github.com/IN-CORE/incore-docs/assets/2397115/62d6bfb9-b98a-4a6a-8838-207edd6a3f4d)
