### PR TITLE
Fixes #295 updated minimum python references to 3.9 and added FAQ entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Update damage analysis documentations with hazard object input [#282](https://github.com/IN-CORE/incore-docs/issues/282)
-- Building Portfolio Recovery analysis notebook [286](https://github.com/IN-CORE/incore-docs/issues/286)
+- Building Portfolio Recovery analysis notebook [#286](https://github.com/IN-CORE/incore-docs/issues/286)
+- Minimum version of python references to 3.9 [#295](https://github.com/IN-CORE/incore-docs/issues/295)
 
 ### Fixed
 - The notebook create_network_dataset.ipynb fails on nx.info [#284](https://github.com/IN-CORE/incore-docs/issues/284)

--- a/manual_jb/content/faq.md
+++ b/manual_jb/content/faq.md
@@ -22,6 +22,11 @@
 
 ## pyIncore
 
+*   *What is the minimum version of Python I need?*
+
+    The current minimum version of Python for running the latest pyincore is 3.9 or higher.
+    <br>
+    <br>
 
 *   *What’s the difference between Anaconda, conda, and Miniconda?*
     

--- a/manual_jb/content/getting_started.md
+++ b/manual_jb/content/getting_started.md
@@ -55,7 +55,7 @@ If you don't have Miniconda installed, do the following steps.
    
 3. Create the python environment (for this example we choose `pyincoreEnv`):
     ```
-    conda create -n pyincoreEnv python=3.8
+    conda create -n pyincoreEnv python=3.9
     ```
    
 4. Activate the environment:
@@ -73,7 +73,7 @@ If you don't have Miniconda installed, do the following steps.
     ```
    If the installed pyincore or pyincore-viz version is not the latest or lower than the desired one, specify the version number in installation command.
     ```
-    conda install -c in-core pyincore=1.5.0 (or your version of choice)
+    conda install -c in-core pyincore=1.14.0 (or your version of choice)
     ```
    Version information for pyincore and pyincore-viz can be found in
    - https://anaconda.org/IN-CORE/pyincore

--- a/manual_jb/content/pyincore/install_pyincore.md
+++ b/manual_jb/content/pyincore/install_pyincore.md
@@ -17,7 +17,7 @@ These steps guides you on how to install both pyIncore and Jupyter Notebooks on 
     ```
    If the installed pyincore version is not the latest or lower than the desired one, specify the version number in installation command.
     ```
-    conda install -c in-core pyincore=1.5.0 (or your version of choice)
+    conda install -c in-core pyincore=1.14.0 (or your version of choice)
     ```
    Version information for pyincore and pyincore-viz can be found in
    - https://anaconda.org/IN-CORE/pyincore

--- a/manual_jb/content/pyincore/prerequisites.md
+++ b/manual_jb/content/pyincore/prerequisites.md
@@ -15,16 +15,16 @@
     so installing Python first is not needed. The `conda` is the preferred interface for managing installations 
     and virtual environments with the Miniconda/Anaconda.
 
-- `Python 3.6 through 3.8` <https://www.python.org/>
-    It is common to have more than one Python version installed on your computer. Since we recommend using virtual environment, your
-    Python will be "encapsulated" by the environment with version specified at the environment creation. Deleting environment removes 
+- `Python 3.9 or higher` <https://www.python.org/>
+    It is common to have more than one Python version installed on your computer. Since we recommend using a virtual environment, your
+    Python will be "encapsulated" by the environment with the version specified at the environment creation. Deleting the environment removes
     that particular Python. 
-    If you install Miniconda/Anaconda make sure you are running the correct version of Python, for example `/Users/<username>>/anaconda3/bin/python`.
+    If you install Miniconda/Anaconda, make sure you are running the correct version of Python, for example `/Users/<username>/anaconda3/bin/python`.
     
     The Python big picture: Most out-of-the-box [Windows installations](https://wiki.python.org/moin/BeginnersGuide/Download) do not come with Python pre-installed. On the other hand Mac OS and most 
-    modern Linux distributions do have Python installed. However the version 2.7 pre-installed by Apple is no longer supported (MacOS after 10.15 Catalina
+    modern Linux distributions do have Python installed. However, the version 2.7 pre-installed by Apple is no longer supported (MacOS after 10.15 Catalina
     will not include a default system Python at all). It is common that users [download](https://www.python.org/downloads) and install newer or additional version of Python. 
-    Therefore it is always a good idea to check. Open Windows Powershell or Mac/Linux Terminal, and enter the following:
+    Therefore, it is always a good idea to check. Open Windows Powershell or Mac/Linux Terminal, and enter the following:
     ```
     python --version
     python3 --version
@@ -41,7 +41,7 @@
     Jupyter Notebook is already installed with Anaconda distribution; it has to be installed separately 
     in your virtual environment on Miniconda.
 
-In the Installation section we provide instructions for both environment managers starting with [Miniconda](https://docs.conda.io/en/latest/miniconda.html). 
+In the Installation section, we provide instructions for both environment managers starting with [Miniconda](https://docs.conda.io/en/latest/miniconda.html).
 Similar instructions apply to full [Anaconda](https://docs.anaconda.com/anaconda/install/) manager. Python 3.x is installed with both versions. 
 The following instructions were tested for Mac, Windows and Linux 64-bit OS.
 
@@ -65,7 +65,7 @@ The following instructions were tested for Mac, Windows and Linux 64-bit OS.
 
 4. Create the python environment (for this example we choose `pyincoreEnv`) and activate it (or stay in the `base`):
     ```
-    conda create -n pyincoreEnv python=3.7
+    conda create -n pyincoreEnv python=3.9
     conda activate pyincoreEnv
     ```
 
@@ -94,10 +94,10 @@ The following instructions were tested for Mac, Windows and Linux 64-bit OS.
     
 4. Create the python environment (for this example we choose `pyincoreEnv`) and activate it (or stay in the `base`):
     ```
-    conda create -n pyincoreEnv python=3.8
+    conda create -n pyincoreEnv python=3.9
     conda activate pyincoreEnv
     ```
-    You should see `pyincoreEnv` in parenthesis before the command prompt, meaning you set up the new virtual environment and are now using it.
+    You should see `pyincoreEnv` in parentheses before the command prompt, meaning you set up the new virtual environment and are now using it.
 
 5. Add [conda-forge](https://conda-forge.org/) package repository to your environment:
     ```

--- a/manual_jb/content/pyincore/quick_reference.md
+++ b/manual_jb/content/pyincore/quick_reference.md
@@ -15,7 +15,7 @@
    
 4. Create the python environment (for this example we choose `pyincoreEnv`):
     ```
-    conda create -n pyincoreEnv python=3.8
+    conda create -n pyincoreEnv python=3.9
     ```
    
 5. Activate the environment:
@@ -29,7 +29,7 @@
     ```
    If the installed pyincore or pyincore-viz version is not the latest or lower than the desired one, specify the version number in installation command.
     ```
-    conda install -c in-core pyincore-viz=1.7.0 (or your version of choice)
+    conda install -c in-core pyincore-viz=1.8.3 (or your version of choice)
     ```
    Version information for pyincore and pyincore-viz can be found in
     - https://anaconda.org/IN-CORE/pyincore


### PR DESCRIPTION
Changed examples that showed creating the environment with python 3.8 to 3.9. I also added an FAQ entry. I did leave one python 3.7 reference in the FAQ because it talked about downgrades that can happen when installing with Conda. I thought that was fine since above it I added that the minimum version for the latest pyincore is 3.9.