### PR TITLE
306 redirect swagger api page to login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Slack channel information to getting started and contact page [#289](https://github.com/IN-CORE/incore-docs/issues/289)
+- Add requestHandler in swagger docs to redirect to login page if any of the urls passed returns 401 [#306](https://github.com/IN-CORE/incore-docs/issues/306)
 
 ### Changed
 - Update damage analysis documentations with hazard object input [#282](https://github.com/IN-CORE/incore-docs/issues/282)

--- a/restapi/index.html
+++ b/restapi/index.html
@@ -20,8 +20,8 @@
 
 
             // Function to handle 401 Unauthorized errors
-            function handleUnauthorizedError(request) {
-                console.error("Unauthorized error. Redirecting to login page:", request);
+            function handleUnauthorizedError(response) {
+                console.error("Unauthorized error. Redirecting to login page:", response);
                 window.location.replace(window.location.protocol + "//" + window.location.host + "/login");
             }
 
@@ -47,11 +47,11 @@
                 DisableTryItOutPlugin
               ],
               layout: "StandaloneLayout",
-              responseInterceptor: (request) => {
+              responseInterceptor: (response) => {
                 if (response.status === 401) {
-                    handleUnauthorizedError(request);
+                    handleUnauthorizedError(response);
                 }
-                return request;
+                return response;
               }
             });
             window.ui = ui

--- a/restapi/index.html
+++ b/restapi/index.html
@@ -48,8 +48,8 @@
                 DisableTryItOutPlugin
               ],
               layout: "StandaloneLayout",
-              requestInterceptor: (request) => {
-                if (request.response.status === 401) {
+              responseInterceptor: (request) => {
+                if (response.status === 401) {
                     handleUnauthorizedError(request);
                 }
                 return request;

--- a/restapi/index.html
+++ b/restapi/index.html
@@ -14,7 +14,6 @@
         <div id="swagger-ui"></div>
         <script src="https://unpkg.com/swagger-ui-dist@5.3.1/swagger-ui-standalone-preset.js"></script>
         <script src="https://unpkg.com/swagger-ui-dist@5.3.1/swagger-ui-bundle.js"></script>
-        <script crossorigin src="https://unpkg.com/universal-cookie@6/umd/universalCookie.min.js"></script>
 
         <script>
           window.onload = function() {

--- a/restapi/index.html
+++ b/restapi/index.html
@@ -14,9 +14,18 @@
         <div id="swagger-ui"></div>
         <script src="https://unpkg.com/swagger-ui-dist@5.3.1/swagger-ui-standalone-preset.js"></script>
         <script src="https://unpkg.com/swagger-ui-dist@5.3.1/swagger-ui-bundle.js"></script>
+        <script crossorigin src="https://unpkg.com/universal-cookie@6/umd/universalCookie.min.js"></script>
 
         <script>
           window.onload = function() {
+
+
+            // Function to handle 401 Unauthorized errors
+            function handleUnauthorizedError(request) {
+                console.error("Unauthorized error. Redirecting to login page:", request);
+                window.location.replace(window.location.protocol + "//" + window.location.host + "/login");
+            }
+
             // Build a system
             const ui = SwaggerUIBundle({
               urls: [
@@ -39,25 +48,12 @@
                 DisableTryItOutPlugin
               ],
               layout: "StandaloneLayout",
-                // requestInterceptor: function (request) {
-                // // Intercept requests and handle errors
-                // return new Promise(function (resolve, reject) {
-                //     fetch(request.url, request)
-                //         .then(function (response) {
-                //             if (!response.ok) {
-                //                 throw new
-                //                 Error(`Please make sure you login at ${window.location.protocol}//${window.location.host}/login first.`);
-                //             }
-                //             return response.text();
-                //         })
-                //         .then(function (responseText) {
-                //             resolve({data: responseText, status: 200});
-                //         })
-                //         .catch(function (error) {
-                //             reject(error);
-                //         });
-                // });
-            // },
+              requestInterceptor: (request) => {
+                if (request.response.status === 401) {
+                    handleUnauthorizedError(request);
+                }
+                return request;
+              }
             });
             window.ui = ui
           };


### PR DESCRIPTION
I have added a responseInterceptor to handle 401 response issues incurred in the calls made to URL arrays supplied since its the openAPI.json specs that face issues when being fetched. Hopefully with this redirect and UI's login redirect back to where the request came from will create a smooth jump from SwaggerDoc -> UI Login Page -> SwaggerDoc

I don't know how to test it without deploying it ¯\_(ツ)_/¯