### PR TITLE
Updated key in residential building recovery notebook

### DIFF
--- a/notebooks/residential_building_recovery.ipynb
+++ b/notebooks/residential_building_recovery.ipynb
@@ -131,7 +131,7 @@
    "outputs": [],
    "source": [
     "# Retrieve result dataset\n",
-    "result = res_recovery.get_output_dataset(\"residential_building_recovery\")\n",
+    "result = res_recovery.get_output_dataset(\"recovery\")\n",
     "\n",
     "# Convert dataset to Pandas DataFrame\n",
     "df = result.get_dataframe_from_csv()\n",


### PR DESCRIPTION
Updated the key for residential building recovery. It was recently changed to "recovery" instead of "residential_building_recovery"